### PR TITLE
bump version to 2.0.0 to indicate Devnet 2 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "wasm-host"]
 
 [package]
 name = "craft"
-version = "0.4.0"
+version = "2.0.0"
 edition = "2021"
 description = "An interactive CLI tool for building and testing WASM smart contracts"
 authors = ["Your Name <your.email@example.com>"]


### PR DESCRIPTION
for each new Devnet (Devnet 3, Devnet 4, etc.) we'll bump the major version number as an indication that the tool is updated for use with that Devnet. Currently we are on Devnet2