### PR TITLE
chore: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+- repo: local
+  hooks:
+    - id: rust-linting
+      name: Rust linting
+      description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
+      entry: cargo fmt --all --
+      pass_filenames: true
+      types: [file, rust]
+      language: system
+    - id: rust-clippy
+      name: Rust clippy
+      description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
+      entry: cargo clippy --all-targets --all-features -- -Dclippy::all
+      pass_filenames: false
+      types: [file, rust]
+      language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,18 @@
-- repo: local
-  hooks:
-    - id: rust-linting
-      name: Rust linting
-      description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
-      entry: cargo fmt --all --
-      pass_filenames: true
-      types: [file, rust]
-      language: system
-    - id: rust-clippy
-      name: Rust clippy
-      description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-      entry: cargo clippy --all-targets --all-features -- -Dclippy::all
-      pass_filenames: false
-      types: [file, rust]
-      language: system
+# .pre-commit-config.yaml
+repos:
+  - repo: local
+    hooks:
+      - id: rust-linting
+        name: Rust linting
+        description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
+        entry: cargo fmt --all --
+        pass_filenames: true
+        types: [file, rust]
+        language: system
+      - id: rust-clippy
+        name: Rust clippy
+        description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
+        entry: cargo clippy --all-targets --all-features -- -Dclippy::all
+        pass_filenames: false
+        types: [file, rust]
+        language: system


### PR DESCRIPTION
Run `fmt` and `clippy` on commit, to make it easier to automatically use those (if your IDE doesn't support)

You can install this by running `pre-commit install` in the repo