### PR TITLE
chore: bump version and remove `authors`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,11 @@ anyhow = "1.0"
 bs58 = "0.5"
 clap = { version = "4.4", features = ["derive"] }
 colored = "2.1"
-console = "0.15"
-dirs = "5.0"
 hex = "0.4"
-indicatif = "0.17"
 inquire = "0.6"
 regex = "1.10"
 ripemd = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 sha2 = "0.10"
 tokio = { version = "1.36", features = ["full"] }
 walkdir = "2.4"


### PR DESCRIPTION
Reflect devnet2 compatibility in version string

The `authors` field is deprecated

Alphabetize dependencies