### PR TITLE
Align all versions to `0.5.1-devnet5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "craft"
-version = "0.5.1"
+version = "0.5.1-devnet5"
 dependencies = [
  "anyhow",
  "atty",
@@ -2860,7 +2860,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-host"
-version = "0.1.0"
+version = "0.5.1-devnet5"
 dependencies = [
  "bigdecimal",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "craft"
-version = "0.5.1"
+version = "0.5.1-devnet5"
 edition = "2024"
 description = "Command-line tool for building, testing, and deploying XRPL smart contracts in WASM"
 license = "ISC"

--- a/projects/decoder_tests/Cargo.lock
+++ b/projects/decoder_tests/Cargo.lock
@@ -11,4 +11,4 @@ dependencies = [
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"

--- a/projects/float_tests/Cargo.lock
+++ b/projects/float_tests/Cargo.lock
@@ -11,4 +11,4 @@ dependencies = [
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"

--- a/projects/kyc/Cargo.lock
+++ b/projects/kyc/Cargo.lock
@@ -11,4 +11,4 @@ dependencies = [
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"

--- a/projects/ledger_sqn/Cargo.lock
+++ b/projects/ledger_sqn/Cargo.lock
@@ -11,4 +11,4 @@ dependencies = [
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"

--- a/projects/nft_owner/Cargo.lock
+++ b/projects/nft_owner/Cargo.lock
@@ -11,4 +11,4 @@ dependencies = [
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"

--- a/projects/notary/Cargo.lock
+++ b/projects/notary/Cargo.lock
@@ -11,4 +11,4 @@ dependencies = [
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"

--- a/projects/oracle/Cargo.lock
+++ b/projects/oracle/Cargo.lock
@@ -11,4 +11,4 @@ dependencies = [
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"

--- a/projects/xrpl_std_example/Cargo.lock
+++ b/projects/xrpl_std_example/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "xrpl-std"
-version = "0.0.1"
+version = "0.5.1-devnet5"
 
 [[package]]
 name = "xrpl_std_example"

--- a/wasm-host/Cargo.toml
+++ b/wasm-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-host"
-version = "0.1.0"
+version = "0.5.1-devnet5"
 edition = "2024"
 
 [dependencies]

--- a/xrpl-std/Cargo.lock
+++ b/xrpl-std/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "xrpl-std"
-version = "0.5.0-devnet5"
+version = "0.5.1-devnet5"

--- a/xrpl-std/Cargo.toml
+++ b/xrpl-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xrpl-std"
-version = "0.5.0-devnet5"
+version = "0.5.1-devnet5"
 edition = "2024"
 description = "Standard library for XRPL WebAssembly smart contracts"
 license = "ISC"


### PR DESCRIPTION
## High Level Overview of Change

The current versions of various Craft artifiacts are not aligned with each other. For now, we want them all to match (one day, post-1.0-release), we'll likely let them diverge.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan
n/a