### PR TITLE
Cleanup struct derives

### DIFF
--- a/projects/kyc/src/lib.rs
+++ b/projects/kyc/src/lib.rs
@@ -17,8 +17,9 @@ pub extern "C" fn finish() -> i32 {
     let account_id = match current_escrow.get_destination() {
         Ok(account_id) => account_id,
         Err(e) => {
-            let _ = trace_num("Error getting destination", e.code() as i64);
-            return e.code(); // <-- Do not execute the escrow.
+            let error_code = e.code();
+            let _ = trace_num("Error getting destination", error_code as i64);
+            return error_code; // <-- Do not execute the escrow.
         }
     };
 
@@ -36,8 +37,9 @@ pub extern "C" fn finish() -> i32 {
             1
         }
         Err(e) => {
-            let _ = trace_num("Error getting credential keylet", e.code() as i64);
-            e.code() // <-- Do not execute the escrow.
+            let error_code = e.code();
+            let _ = trace_num("Error getting credential keylet", error_code as i64);
+            error_code // <-- Do not execute the escrow.
         }
     }
 }

--- a/projects/nft_owner/src/lib.rs
+++ b/projects/nft_owner/src/lib.rs
@@ -49,8 +49,9 @@ pub extern "C" fn finish() -> i32 {
             }
         }
         Err(e) => {
-            let _ = trace_num("Error getting first memo:", e.code() as i64);
-            return e.code(); // <-- Do not execute the escrow.
+            let error_code = e.code();
+            let _ = trace_num("Error getting first memo:", error_code as i64);
+            return error_code; // <-- Do not execute the escrow.
         }
     };
 
@@ -60,16 +61,21 @@ pub extern "C" fn finish() -> i32 {
     let destination = match current_escrow.get_destination() {
         Ok(destination) => destination,
         Err(e) => {
-            let _ = trace_num("Error getting current ledger destination:", e.code() as i64);
-            return e.code(); // <-- Do not execute the escrow.
+            let error_code = e.code();
+            let _ = trace_num(
+                "Error getting current ledger destination:",
+                error_code as i64,
+            );
+            return error_code; // <-- Do not execute the escrow.
         }
     };
 
     match get_nft(&destination, &nft) {
         Ok(_) => 1,
         Err(e) => {
-            let _ = trace_num("Error getting first memo:", e.code() as i64);
-            e.code() // <-- Do not execute the escrow.
+            let error_code = e.code();
+            let _ = trace_num("Error getting first memo:", error_code as i64);
+            error_code // <-- Do not execute the escrow.
         }
     }
 }

--- a/projects/notary/src/lib.rs
+++ b/projects/notary/src/lib.rs
@@ -17,8 +17,9 @@ pub extern "C" fn finish() -> i32 {
     let tx_account = match escrow_finish.get_account() {
         Ok(v) => v,
         Err(e) => {
-            let _ = trace_num("Error in Notary contract", e.code() as i64);
-            return e.code(); // Must return to short circuit.
+            let error_code = e.code();
+            let _ = trace_num("Error in Notary contract", error_code as i64);
+            return error_code; // Must return to short circuit.
         }
     };
 

--- a/projects/xrpl_std_examples/trace_escrow_finish/src/lib.rs
+++ b/projects/xrpl_std_examples/trace_escrow_finish/src/lib.rs
@@ -49,8 +49,11 @@ pub extern "C" fn finish() -> i32 {
 
         // Trace Field: TransactionType
         let transaction_type: TransactionType = escrow_finish.get_transaction_type().unwrap();
-        assert_eq!(transaction_type, TransactionType::EscrowFinish);
         let tx_type_bytes: [u8; 2] = transaction_type.into();
+        assert_eq!(
+            escrow_finish.get_transaction_type().unwrap(),
+            TransactionType::EscrowFinish
+        );
         let _ = trace_data(
             "  TransactionType (EscrowFinish):",
             &tx_type_bytes,

--- a/wasm-host/src/hashing.rs
+++ b/wasm-host/src/hashing.rs
@@ -5,7 +5,6 @@ pub type Hash256 = Vec<u8>;
 
 #[repr(u16)]
 #[allow(dead_code)]
-// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LedgerNameSpace {
     Account = b'a' as u16,
     DirNode = b'd' as u16,

--- a/xrpl-std/src/core/current_tx/escrow_finish.rs
+++ b/xrpl-std/src/core/current_tx/escrow_finish.rs
@@ -34,8 +34,7 @@ use crate::core::current_tx::traits::{EscrowFinishFields, TransactionCommonField
 /// This structure has no runtime overhead as it contains no data fields. All field
 /// access is performed through the trait methods, which directly call the underlying
 /// host functions to retrieve data from the current transaction context.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct EscrowFinish;
 
 /// Implementation of common transaction fields for EscrowFinish transactions.

--- a/xrpl-std/src/core/ledger_objects/account_root.rs
+++ b/xrpl-std/src/core/ledger_objects/account_root.rs
@@ -5,8 +5,7 @@ use crate::core::types::keylets::account_keylet;
 use crate::host;
 use host::Error;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AccountRoot {
     pub slot_num: i32,
 }

--- a/xrpl-std/src/core/ledger_objects/current_escrow.rs
+++ b/xrpl-std/src/core/ledger_objects/current_escrow.rs
@@ -1,7 +1,6 @@
 use crate::core::ledger_objects::traits::{CurrentEscrowFields, CurrentLedgerObjectCommonFields};
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CurrentEscrow;
 
 impl CurrentLedgerObjectCommonFields for CurrentEscrow {}

--- a/xrpl-std/src/core/ledger_objects/escrow.rs
+++ b/xrpl-std/src/core/ledger_objects/escrow.rs
@@ -1,7 +1,6 @@
 use crate::core::ledger_objects::traits::{EscrowFields, LedgerObjectCommonFields};
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Escrow {
     slot_num: i32,
 }

--- a/xrpl-std/src/core/locator.rs
+++ b/xrpl-std/src/core/locator.rs
@@ -8,8 +8,7 @@ const LOCATOR_BUFFER_SIZE: usize = 64;
 /// A Locator allows a WASM developer located any field in any object (even nested fields) by
 /// specifying a `slot_num` (1 byte); a `locator_field_type` (1 byte); then one of an `sfield` (4
 /// bytes) or an `index` (4 bytes).
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Locator {
     // The first packed value is 6 bytes; All nested/packed values are 5 bytes; so 64 bytes allow
     // 12 nested levels of access.

--- a/xrpl-std/src/core/types/account_id.rs
+++ b/xrpl-std/src/core/types/account_id.rs
@@ -1,7 +1,6 @@
 pub const ACCOUNT_ID_SIZE: usize = 20;
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct AccountID(pub [u8; ACCOUNT_ID_SIZE]);
 
 impl From<[u8; ACCOUNT_ID_SIZE]> for AccountID {

--- a/xrpl-std/src/core/types/amount/asset.rs
+++ b/xrpl-std/src/core/types/amount/asset.rs
@@ -4,13 +4,11 @@ use crate::core::types::amount::mpt_id::MptId;
 
 /// Struct to represent an Asset of type XRP. Exists so that other structs can restrict type
 /// information to XRP in their declarations (this is not possible with just the `Asset` enum below).
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct XrpAsset {}
 
 /// Defines an asset for IOUs.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct IouAsset {
     issuer: AccountID,
     currency_code: CurrencyCode,
@@ -18,16 +16,14 @@ pub struct IouAsset {
 
 /// Struct to represent an Asset of type MPT. Exists so that other structs can restrict type
 /// information to XRP in their declarations (this is not possible with just the `Asset` enum below).
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MptAsset {
     mpt_id: MptId,
 }
 
 /// Represents an asset withoout a value, such as reading `Asset1` and `Asset2` in AMM ledger
 /// objects.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Asset {
     XRP(XrpAsset),
     IOU(IouAsset),

--- a/xrpl-std/src/core/types/amount/currency_code.rs
+++ b/xrpl-std/src/core/types/amount/currency_code.rs
@@ -2,8 +2,7 @@ pub const CURRENCY_CODE_SIZE: usize = 20;
 pub const STANDARD_CURRENCY_CODE_SIZE: usize = 3; // For standard currencies like USD, EUR, etc.
 
 /// Represents a currency code in the XRPL, which is a 20-byte identifier.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CurrencyCode(pub [u8; CURRENCY_CODE_SIZE]);
 
 impl CurrencyCode {

--- a/xrpl-std/src/core/types/amount/mpt_id.rs
+++ b/xrpl-std/src/core/types/amount/mpt_id.rs
@@ -4,13 +4,12 @@ pub const MPT_ID_SIZE: usize = 24;
 pub const MPT_SEQUENCE_NUM_SIZE: usize = 4;
 
 /// Holds an MPT Identifier, which consists of a 4-byte sequence number and a 20-byte account id.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct MptId([u8; MPT_ID_SIZE]);
 
 impl MptId {
     /// Creates a new MptId from a sequence number and an issuer account ID.
-    pub fn new(sequence_num: u32, issuer: AccountID) -> Self {
+    pub fn new(sequence_num: u32, issuer: &AccountID) -> Self {
         let mut bytes = [0u8; MPT_ID_SIZE];
 
         // Set the sequence number (first 4 bytes)
@@ -48,8 +47,8 @@ impl From<[u8; 24]> for MptId {
     }
 }
 
-impl From<(u32, AccountID)> for MptId {
-    fn from(value: (u32, AccountID)) -> Self {
+impl From<(u32, &AccountID)> for MptId {
+    fn from(value: (u32, &AccountID)) -> Self {
         MptId::new(value.0, value.1)
     }
 }
@@ -66,7 +65,7 @@ mod tests {
 
         // Create an MptId using the constructor
         let sequence_num = 12345u32;
-        let mpt_id = MptId::new(sequence_num, account_id);
+        let mpt_id = MptId::new(sequence_num, &account_id);
 
         // Verify the sequence number and issuer
         assert_eq!(mpt_id.get_sequence_num(), sequence_num);
@@ -103,7 +102,7 @@ mod tests {
 
         // Create an MptId from a tuple
         let sequence_num = 54321u32;
-        let mpt_id = MptId::from((sequence_num, account_id));
+        let mpt_id = MptId::from((sequence_num, &account_id));
 
         // Verify the sequence number and issuer
         assert_eq!(mpt_id.get_sequence_num(), sequence_num);

--- a/xrpl-std/src/core/types/amount/opaque_float.rs
+++ b/xrpl-std/src/core/types/amount/opaque_float.rs
@@ -2,8 +2,7 @@
 /// `exponent` and `mantissa` that rippled uses to represent a floating point number. Craft treats
 /// this as an opaque so that developers don't try and do arithmetic with these bytes directly, but
 /// instead use Host functions for any arithmetic on this type of number.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct OpaqueFloat(pub [u8; 8]);
 
 impl OpaqueFloat {

--- a/xrpl-std/src/core/types/amount/token_amount.rs
+++ b/xrpl-std/src/core/types/amount/token_amount.rs
@@ -72,8 +72,7 @@ pub const TOKEN_AMOUNT_SIZE: usize = 48;
 ///      └──────────────────┘└──────────────────┘
 /// ```
 ///
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum TokenAmount {
     XRP {
         // amount: Amount::XRP,

--- a/xrpl-std/src/core/types/blob.rs
+++ b/xrpl-std/src/core/types/blob.rs
@@ -1,5 +1,4 @@
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Blob {
     pub data: [u8; 1024],
 

--- a/xrpl-std/src/core/types/credentials.rs
+++ b/xrpl-std/src/core/types/credentials.rs
@@ -1,9 +1,7 @@
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CredentialID(pub [u8; 256]);
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(C)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct CredentialIDs {
     pub credential_ids: [CredentialID; 10],
     pub num_credential_ids: u8, // Max of 10!
@@ -27,8 +25,8 @@ impl CredentialIDs {
         // Copy the provided IDs into the start of the array.
         // Using `enumerate` gives us the index `i`.
         // Since CredentialID is Copy, `*id` performs a cheap copy.
-        for (i, &id) in ids.iter().enumerate() {
-            credential_ids_array[i] = id;
+        for (i, id) in ids.iter().enumerate() {
+            credential_ids_array[i] = CredentialID(id.0);
         }
 
         CredentialIDs {
@@ -49,8 +47,8 @@ impl TryFrom<&[CredentialID]> for CredentialIDs {
         }
 
         let mut credential_ids_array = [EMPTY_CREDENTIAL_ID; 10];
-        for (i, &id) in ids.iter().enumerate() {
-            credential_ids_array[i] = id;
+        for (i, id) in ids.iter().enumerate() {
+            credential_ids_array[i] = CredentialID(id.0);
         }
 
         Ok(CredentialIDs {

--- a/xrpl-std/src/core/types/hash_256.rs
+++ b/xrpl-std/src/core/types/hash_256.rs
@@ -2,8 +2,7 @@
 
 pub const HASH256_SIZE: usize = 32;
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Hash256(pub [u8; HASH256_SIZE]);
 
 // Implement From<[u8; 32]> to create Hash256 from the array type

--- a/xrpl-std/src/core/types/transaction_type.rs
+++ b/xrpl-std/src/core/types/transaction_type.rs
@@ -1,6 +1,6 @@
 /// The type of any given XRPL transaction
 #[repr(i16)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TransactionType {
     Invalid = -1,
     Payment = 0,

--- a/xrpl-std/src/core/types/uint_128.rs
+++ b/xrpl-std/src/core/types/uint_128.rs
@@ -2,8 +2,7 @@
 
 pub const UINT128_SIZE: usize = 16;
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct UInt128(pub [u8; UINT128_SIZE]);
 
 // Implement From<[u8; 16]> to create UInt128 from the array type

--- a/xrpl-std/src/host/mod.rs
+++ b/xrpl-std/src/host/mod.rs
@@ -73,10 +73,11 @@ impl<T> Result<T> {
         match self {
             Result::Ok(t) => t,
             Result::Err(error) => {
-                let _ = trace::trace_num("error_code=", error.code() as i64);
+                let error_code = error.code();
+                let _ = trace::trace_num("error_code=", error_code as i64);
                 panic!(
                     "called `Result::unwrap()` on an `Err` with code: {}",
-                    error.code()
+                    error_code
                 )
             }
         }
@@ -103,11 +104,12 @@ impl<T> Result<T> {
     #[inline]
     pub fn unwrap_or_panic(self) -> T {
         self.unwrap_or_else(|error| {
-            let _ = trace::trace_num("error_code=", error.code() as i64);
+            let error_code = error.code();
+            let _ = trace::trace_num("error_code=", error_code as i64);
             core::panic!(
                 "Failed in {}: error_code={}",
                 core::panic::Location::caller(),
-                error.code()
+                error_code
             );
         })
     }
@@ -126,7 +128,7 @@ impl From<i64> for Result<u64> {
 /// Possible errors returned by XRPL Programmability APIs.
 ///
 /// Errors are global across all Programmability APIs.
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 #[repr(i32)]
 pub enum Error {
     /// A pointer or buffer length provided as a parameter described memory outside the allowed memory region.

--- a/xrpl-std/src/host/trace.rs
+++ b/xrpl-std/src/host/trace.rs
@@ -6,7 +6,7 @@ use crate::host::Result;
 use core::ptr;
 
 /// Data representation
-#[derive(Clone, Copy)]
+#[repr(u8)]
 pub enum DataRepr {
     /// As UTF-8
     AsUTF8 = 0,


### PR DESCRIPTION
## High Level Overview of Change

* Remove `#[repr(C)]` from structs that don’t cross the FFI boundary (they don’t need it).
* Remove `Clone` and `Copy` derive instructions so that no copies are made without the developer explicitely making them, enforcing very strict ownership semantics.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release