### PR TITLE
chore: bump JS packages to new betas

### DIFF
--- a/reference/js/deploy_sample.js
+++ b/reference/js/deploy_sample.js
@@ -4,13 +4,14 @@ const path = require('path')
 
 const sleep = ms => new Promise(r => setTimeout(r, ms))
 
-if (process.argv.length != 3) {
+if (process.argv.length < 3) {
   console.error(
     'Usage: ' +
       process.argv[0] +
       ' ' +
       process.argv[1] +
-      ' (path/to/file.wasm OR path/to/file.hex OR project_name)',
+      ' (path/to/file.wasm OR project_name)' +
+      '[Account1 Account1Seed [Account2 Account2Seed]]',
   )
   process.exit(1)
 }
@@ -56,8 +57,27 @@ async function submit(tx, wallet, debug = true) {
 async function deploy() {
   await client.connect()
   console.log("connected")
-  const {wallet} = await client.fundWallet()
-  const {wallet: wallet2 } = await client.fundWallet()
+  let wallet, wallet2
+  if (process.argv.length > 3) {
+    const account = process.argv[3]
+    const accountSecret = process.argv[4]
+    wallet = xrpl.Wallet.fromSeed(accountSecret, {masterAddress: account})
+
+    if (process.argv.length > 5) {
+      const account2 = process.argv[5]
+      const accountSecret2 = process.argv[6]
+      wallet2 = xrpl.Wallet.fromSeed(accountSecret2, {masterAddress: account2})
+    } else {
+      wallet2 = xrpl.Wallet.generate()
+    }
+  } else {
+    wallet = xrpl.Wallet.generate()
+    wallet2 = xrpl.Wallet.generate()
+    await client.fundWallet(wallet)
+    await client.fundWallet(wallet2)
+  }
+
+
   console.log(`\nFunded accounts:`)
   console.log(`Account 1 - Address: ${wallet.address}`)
   console.log(`Account 1 - Secret: ${wallet.seed}`)

--- a/reference/js/deploy_sample.js
+++ b/reference/js/deploy_sample.js
@@ -83,7 +83,6 @@ async function deploy() {
     FinishAfter: close_time + 10, // about 10 seconds. After this time, the escrow can be finished.
     FinishFunction: finish,
     Data: xrpl.xrpToDrops(70),
-    Fee: '1000000',
   }, wallet)
 
   if (response1.result.meta.TransactionResult !== "tesSUCCESS") process.exit(1)

--- a/reference/js/deploy_sample.js
+++ b/reference/js/deploy_sample.js
@@ -27,7 +27,7 @@ function getFinishFunctionFromFile(filePath) {
   if (filePath.endsWith('.wasm') || filePath.endsWith('.hex')) {
     absolutePath = path.resolve(filePath)
   } else {
-    absolutePath = path.resolve(__dirname, `../../projects/${filePath}/target/wasm32-unknown-unknown/release/${filePath}.wasm`)
+    absolutePath = path.resolve(__dirname, `../../projects/target/wasm32-unknown-unknown/release/${filePath}.wasm`)
   }
   try {
       const data = fs.readFileSync(absolutePath)
@@ -83,6 +83,7 @@ async function deploy() {
     FinishAfter: close_time + 10, // about 10 seconds. After this time, the escrow can be finished.
     FinishFunction: finish,
     Data: xrpl.xrpToDrops(70),
+    Fee: '1000000',
   }, wallet)
 
   if (response1.result.meta.TransactionResult !== "tesSUCCESS") process.exit(1)

--- a/reference/js/deploy_sample_standalone.js
+++ b/reference/js/deploy_sample_standalone.js
@@ -28,7 +28,7 @@ function getFinishFunctionFromFile(filePath) {
   if (filePath.endsWith('.wasm')) {
     absolutePath = path.resolve(filePath)
   } else {
-    absolutePath = path.resolve(__dirname, `../../projects/${filePath}/target/wasm32-unknown-unknown/release/${filePath}.wasm`)
+    absolutePath = path.resolve(__dirname, `../../projects/target/wasm32-unknown-unknown/release/${filePath}.wasm`)
   }
   try {
     const data = fs.readFileSync(absolutePath)

--- a/reference/js/package-lock.json
+++ b/reference/js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "xrpl-escrow-extension",
       "version": "1.0.0",
       "dependencies": {
-        "xrpl": "^4.3.0-smartescrow.3"
+        "xrpl": "^4.5.0-smartescrow.1"
       }
     },
     "node_modules/@noble/curves": {
@@ -73,6 +73,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@xrplf/isomorphic/-/isomorphic-1.0.1.tgz",
       "integrity": "sha512-0bIpgx8PDjYdrLFeC3csF305QQ1L7sxaWnL5y71mCvhenZzJgku9QsA+9QCXBC1eNYtxWO/xR91zrXJy2T/ixg==",
+      "license": "ISC",
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "eventemitter3": "5.0.1",
@@ -83,18 +84,20 @@
       }
     },
     "node_modules/@xrplf/secret-numbers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-1.0.0.tgz",
-      "integrity": "sha512-qsCLGyqe1zaq9j7PZJopK+iGTGRbk6akkg6iZXJJgxKwck0C5x5Gnwlb1HKYGOwPKyrXWpV6a2YmcpNpUFctGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
+      "integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
+      "license": "ISC",
       "dependencies": {
-        "@xrplf/isomorphic": "^1.0.0",
+        "@xrplf/isomorphic": "^1.0.1",
         "ripple-keypairs": "^2.0.0"
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
-      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -102,12 +105,14 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/ripple-address-codec": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-5.0.0.tgz",
       "integrity": "sha512-de7osLRH/pt5HX2xw2TRJtbdLLWHu0RXirpQaEeCnWKY5DYHykh3ETSkofvm0aX0LJiV7kwkegJxQkmbO94gWw==",
+      "license": "ISC",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "@xrplf/isomorphic": "^1.0.0"
@@ -117,9 +122,10 @@
       }
     },
     "node_modules/ripple-binary-codec": {
-      "version": "2.4.0-smartescrow.2",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.4.0-smartescrow.2.tgz",
-      "integrity": "sha512-OzS1gEJL8SJiQ6UeSkE3sxvti5SnbApI5BchLY9Zt+sqP0pNyCUGgyvshe3OQPzKFIS2e8tIWn/mVSocvXcbJQ==",
+      "version": "2.6.0-smartescrow.1",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.6.0-smartescrow.1.tgz",
+      "integrity": "sha512-RklDIpEpeabS3naFCR9x4Ewp/znNUyaGhsB6utNWafHVArtqKjZQXsXT4yoFfNu28ZchlP+1hwbe+fJUeTWfbQ==",
+      "license": "ISC",
       "dependencies": {
         "@xrplf/isomorphic": "^1.0.1",
         "bignumber.js": "^9.0.0",
@@ -133,6 +139,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-2.0.0.tgz",
       "integrity": "sha512-b5rfL2EZiffmklqZk1W+dvSy97v3V/C7936WxCCgDynaGPp7GE6R2XO7EU9O2LlM/z95rj870IylYnOQs+1Rag==",
+      "license": "ISC",
       "dependencies": {
         "@noble/curves": "^1.0.0",
         "@xrplf/isomorphic": "^1.0.0",
@@ -143,9 +150,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -163,18 +171,19 @@
       }
     },
     "node_modules/xrpl": {
-      "version": "4.3.0-smartescrow.3",
-      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.3.0-smartescrow.3.tgz",
-      "integrity": "sha512-7dtAlTwqbJBxPhS5gxJVeRraJd638eBmtdboFVh672vPffhFEek5zHOt/rbnvCGUHQP57MhTkLfwMUwLkFMygg==",
+      "version": "4.5.0-smartescrow.1",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.5.0-smartescrow.1.tgz",
+      "integrity": "sha512-0BRYJpgj4dH2KcC2VTi5orJHteXtQ7xJGtrBaSkB46g0GljRRUUGv1D6wZLlv6sd9oPyRz4h2CAziLnBrcSLUQ==",
+      "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.3.1",
         "@scure/bip39": "^1.2.1",
         "@xrplf/isomorphic": "^1.0.1",
-        "@xrplf/secret-numbers": "^1.0.0",
+        "@xrplf/secret-numbers": "^2.0.0",
         "bignumber.js": "^9.0.0",
         "eventemitter3": "^5.0.1",
         "ripple-address-codec": "^5.0.0",
-        "ripple-binary-codec": "^2.4.0-smartescrow.2",
+        "ripple-binary-codec": "^2.6.0-smartescrow.1",
         "ripple-keypairs": "^2.0.0"
       },
       "engines": {
@@ -231,18 +240,18 @@
       }
     },
     "@xrplf/secret-numbers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-1.0.0.tgz",
-      "integrity": "sha512-qsCLGyqe1zaq9j7PZJopK+iGTGRbk6akkg6iZXJJgxKwck0C5x5Gnwlb1HKYGOwPKyrXWpV6a2YmcpNpUFctGg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@xrplf/secret-numbers/-/secret-numbers-2.0.0.tgz",
+      "integrity": "sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==",
       "requires": {
-        "@xrplf/isomorphic": "^1.0.0",
+        "@xrplf/isomorphic": "^1.0.1",
         "ripple-keypairs": "^2.0.0"
       }
     },
     "bignumber.js": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
-      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA=="
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
     },
     "eventemitter3": {
       "version": "5.0.1",
@@ -259,9 +268,9 @@
       }
     },
     "ripple-binary-codec": {
-      "version": "2.4.0-smartescrow.2",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.4.0-smartescrow.2.tgz",
-      "integrity": "sha512-OzS1gEJL8SJiQ6UeSkE3sxvti5SnbApI5BchLY9Zt+sqP0pNyCUGgyvshe3OQPzKFIS2e8tIWn/mVSocvXcbJQ==",
+      "version": "2.6.0-smartescrow.1",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-2.6.0-smartescrow.1.tgz",
+      "integrity": "sha512-RklDIpEpeabS3naFCR9x4Ewp/znNUyaGhsB6utNWafHVArtqKjZQXsXT4yoFfNu28ZchlP+1hwbe+fJUeTWfbQ==",
       "requires": {
         "@xrplf/isomorphic": "^1.0.1",
         "bignumber.js": "^9.0.0",
@@ -279,24 +288,24 @@
       }
     },
     "ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "requires": {}
     },
     "xrpl": {
-      "version": "4.3.0-smartescrow.3",
-      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.3.0-smartescrow.3.tgz",
-      "integrity": "sha512-7dtAlTwqbJBxPhS5gxJVeRraJd638eBmtdboFVh672vPffhFEek5zHOt/rbnvCGUHQP57MhTkLfwMUwLkFMygg==",
+      "version": "4.5.0-smartescrow.1",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.5.0-smartescrow.1.tgz",
+      "integrity": "sha512-0BRYJpgj4dH2KcC2VTi5orJHteXtQ7xJGtrBaSkB46g0GljRRUUGv1D6wZLlv6sd9oPyRz4h2CAziLnBrcSLUQ==",
       "requires": {
         "@scure/bip32": "^1.3.1",
         "@scure/bip39": "^1.2.1",
         "@xrplf/isomorphic": "^1.0.1",
-        "@xrplf/secret-numbers": "^1.0.0",
+        "@xrplf/secret-numbers": "^2.0.0",
         "bignumber.js": "^9.0.0",
         "eventemitter3": "^5.0.1",
         "ripple-address-codec": "^5.0.0",
-        "ripple-binary-codec": "^2.4.0-smartescrow.2",
+        "ripple-binary-codec": "^2.6.0-smartescrow.1",
         "ripple-keypairs": "^2.0.0"
       }
     }

--- a/reference/js/package.json
+++ b/reference/js/package.json
@@ -7,6 +7,6 @@
     "test": "node reference/js/escrow_extension.js"
   },
   "dependencies": {
-    "xrpl": "^4.3.0-smartescrow.3"
+    "xrpl": "^4.5.0-smartescrow.1"
   }
 }

--- a/reference/js/test.js
+++ b/reference/js/test.js
@@ -1,5 +1,5 @@
 const fs = require('fs'); // Only in Node.js
-const wasmBuffer = fs.readFileSync('../../projects/ledger_sqn/target/wasm32-unknown-unknown/release/ledger_sqn.wasm');
+const wasmBuffer = fs.readFileSync('../../projects/target/wasm32-unknown-unknown/release/ledger_sqn.wasm');
 
 const importObject = {
     host_lib: {


### PR DESCRIPTION
## High Level Overview of Change

This PR bumps the `xrpl` package in the JS scripts to the latest version of the beta (deployed today).

### Context of Change

Fee changes mean that the old scripts won't work anymore

### Type of Change

- [x] Chore

## Test Plan

CI passes. Scripts work locally.
