### PR TITLE
Add WASM Devnet details for version 6

### DIFF
--- a/DEVNET.md
+++ b/DEVNET.md
@@ -1,6 +1,47 @@
 # WASM Devnet Details
 
-## Devnet5 - 2025-08-04 Release
+## Devnet6 - 2025-09-12 Release
+
+The WASM Devnet (Smart Escrows) has been updated to its sixth monthly release.
+
+The code is essentially feature-complete and moving onto the review and testing phase.
+
+The `rippled` code can be found in this branch: https://github.com/XRPLF/rippled/tree/ripple/smart-escrow
+
+Commit: 4d4a1cfe8238be9830c7712e5879cbefd5f10668
+
+Devnet details:
+
+- URL: wasm.devnet.rippletest.net (port 51234 for HTTP, 51233 for WS)
+- Explorer: https://custom.xrpl.org/wasm.devnet.rippletest.net
+- Faucet: https://wasmfaucet.devnet.rippletest.net/accounts
+
+`rippled` Changelog:
+
+- Update the fees and reserves
+  - `EscrowCreate` for a Smart Escrow now costs 100 drops + 5 drops per byte in the `FinishFunction`, and a Smart Escrow is charged 1 additional object reserve per 500 bytes (beyond the first 500 bytes, which are included in the first object reserve)
+- Adjust the function signatures of `get_ledger_sqn` and `get_parent_ledger_time` to return the value instead of a buffer
+  - This is already reflected in XLS-102
+- Add the last set of host functions - mostly some missing keylets, like `MPTokenIssuance`
+- Various bugfixes and cleaning up code
+
+Craft Changelog:
+
+- Support the new `rippled` features mentioned above
+- Lots of additional documentation - new docs page: https://ripple.github.io/craft/
+- Significant amounts of code cleanup and reorganization
+  - We have been revamping the repo structure to improve the dev experience
+  - Examples are now in `projects/examples`
+- Various bugfixes and cleaning up code
+
+Tooling:
+- Writing Rust WASM extensions: https://github.com/ripple/craft
+- Python: `xrpl-py v4.4.0b1`
+- JS: `xrpl@4.5.0-smartescrow.2`, `ripple-binary-codec@2.6.0-smartescrow.2` (you can also use the `@smartescrow` or `@smart-escrow` tags)
+
+## Historical WASM Devnets
+
+### Devnet5 - 2025-08-04 Release
 
 The WASM Devnet (Smart Escrows) has been updated to its fifth monthly release.
 
@@ -41,9 +82,6 @@ Tooling:
 - Writing Rust WASM extensions: https://github.com/ripple/craft
 - Python: xrpl-py v4.4.0b0
 - JS: `xrpl@4.5.0-smartescrow.0`, `ripple-binary-codec@2.6.0-smartescrow.0` (you can also use the `@smartescrow` or `@smart-escrow` tags)
-
-
-## Historical WASM Devnets
 
 ### Devnet4 - 2025-07-03 Release
 


### PR DESCRIPTION
Copilot: This pull request updates the `DEVNET.md` documentation to announce the sixth monthly release of the WASM Devnet (Smart Escrows). It provides updated devnet details, summarizes major changes in both the `rippled` and Craft codebases, and revises the tooling section to reflect new package versions and resources. The documentation now also highlights the feature-complete status and the transition to the review and testing phase.

Release and documentation updates:

* Announced the Devnet6 release (2025-09-12), marking the code as feature-complete and entering review/testing. Added updated devnet URLs, explorer, faucet, and the latest commit reference for the `rippled` branch.
* Documented key changes in `rippled`: fee and reserve adjustments for Smart Escrow, updated host functions, and bugfixes/cleanup.
* Summarized major Craft updates: support for new `rippled` features, expanded documentation (including a new docs page), repo reorganization, and bugfixes.
* Updated the tooling section with new Rust, Python, and JS package versions and resources for WASM extension development.
* Clarified historical devnet releases by reorganizing the document structure.