### PR TITLE
fix compareHostFunctions.js

### DIFF
--- a/tools/compareHostFunctions.js
+++ b/tools/compareHostFunctions.js
@@ -75,7 +75,7 @@ async function main() {
     let importHits = [
         ...wasmImportFile.matchAll(
             // parse the WASM host function imports in `WasmVM.cpp`
-            /^ *WASM_IMPORT_FUNC2? *\(i, *([A-Za-z0-9]+), *("([A-Za-z0-9_]+)",)? *hfs, *[0-9]+\);$/gm,
+            /^ *WASM_IMPORT_FUNC2? *\(i, *([A-Za-z0-9]+), *("([A-Za-z0-9_]+)",)? *hfs, *[0-9']+\);$/gm,
         ),
     ]
     const imports = importHits.map((hit) => [hit[1], hit[3] != null ? hit[3] : hit[1]]).sort((a, b) => a[0].localeCompare(b[0]))


### PR DESCRIPTION
## High Level Overview of Change

Fix `compareHostFunctions.js` so that the `host_functions_audit` CI test passes.

### Context of Change

The regex wasn't quite general enough

Fixes #227 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Release Note

<!--
Please write a release note specific to this PR.
REQUIRED if users can experience this change.

Text in this section will be in the release notes, ideally verbatim.
This must be human-written (not autogenerated).
It is usually a line or two.
-->

## Test Plan

CI now passes.
