### PR TITLE
Fixes #216: Unwrap all Trace calls

### DIFF
--- a/projects/e2e-tests/codecov_tests/src/lib.rs
+++ b/projects/e2e-tests/codecov_tests/src/lib.rs
@@ -29,16 +29,16 @@ mod host_bindings_loose {
 fn check_result(result: i32, expected: i32, test_name: &'static str) {
     match result {
         code if code == expected => {
-            let _ = trace_number(test_name, code.into());
+            trace_number(test_name, code.into());
         }
         code if code >= 0 => {
-            let _ = trace(test_name);
-            let _ = trace_number("TEST FAILED", code.into());
+            trace(test_name);
+            trace_number("TEST FAILED", code.into());
             panic!("Unexpected success code: {}", code);
         }
         code => {
-            let _ = trace(test_name);
-            let _ = trace_number("TEST FAILED", code.into());
+            trace(test_name);
+            trace_number("TEST FAILED", code.into());
             panic!("Error code: {}", code);
         }
     }
@@ -54,7 +54,7 @@ where
 
 #[unsafe(no_mangle)]
 pub extern "C" fn finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
 
     // ########################################
     // Step #1: Test all host function happy paths

--- a/projects/e2e-tests/decoder_tests/src/lib.rs
+++ b/projects/e2e-tests/decoder_tests/src/lib.rs
@@ -27,7 +27,7 @@ use xrpl_wasm_std::sfield::{
 use xrpl_wasm_std::{decode_hex_20, decode_hex_32, host, sfield};
 
 fn test_account_root() {
-    let _ = trace("\n$$$ test_account_root $$$");
+    trace("\n$$$ test_account_root $$$");
     let keylet =
         decode_hex_32(b"13F1A95D7AAB7108D5CE7EEAF504B2894B8C674E6D68499076441C4837282BF8").unwrap();
 
@@ -37,36 +37,36 @@ fn test_account_root() {
     let out_len = unsafe {
         get_ledger_obj_field(slot, Account, out_buf.as_mut_ptr(), out_buf.len()) as usize
     };
-    let _ = trace_account_buf("  Account:", &out_buf);
+    trace_account_buf("  Account:", &out_buf);
 
     let mut out_buf = [0u8; 32];
     let out_len = unsafe {
         get_ledger_obj_field(slot, AccountTxnID, out_buf.as_mut_ptr(), out_buf.len()) as usize
     };
-    let _ = trace_data("  AccountTxnID:", &out_buf[0..out_len], DataRepr::AsHex);
+    trace_data("  AccountTxnID:", &out_buf[0..out_len], DataRepr::AsHex);
 
     let mut out_buf = [0u8; 48];
     let out_len = unsafe {
         get_ledger_obj_field(slot, Balance, out_buf.as_mut_ptr(), out_buf.len()) as usize
     };
-    let _ = trace_data("  Balance:", &out_buf[0..out_len], DataRepr::AsHex);
+    trace_data("  Balance:", &out_buf[0..out_len], DataRepr::AsHex);
 
     let mut out_buf = [0u8; 20];
     let out_len =
         unsafe { get_ledger_obj_field(slot, Domain, out_buf.as_mut_ptr(), out_buf.len()) as usize };
-    let _ = trace_data("  Domain:", &out_buf[0..out_len], DataRepr::AsHex);
+    trace_data("  Domain:", &out_buf[0..out_len], DataRepr::AsHex);
 
     let mut out_buf = [0u8; 16];
     let out_len = unsafe {
         get_ledger_obj_field(slot, EmailHash, out_buf.as_mut_ptr(), out_buf.len()) as usize
     };
-    let _ = trace_data("  EmailHash:", &out_buf[0..out_len], DataRepr::AsHex);
+    trace_data("  EmailHash:", &out_buf[0..out_len], DataRepr::AsHex);
 
     let mut out_buf = 0i32;
     let out_len = unsafe {
         get_ledger_obj_field(slot, Flags, (&mut out_buf) as *mut i32 as *mut u8, 4) as usize
     };
-    let _ = trace_num("  Flags:", out_buf as i64);
+    trace_num("  Flags:", out_buf as i64);
 
     let mut out_buf = 0i16;
     let out_len = unsafe {
@@ -77,25 +77,25 @@ fn test_account_root() {
             2,
         ) as usize
     };
-    let _ = trace_num("  LedgerEntryType:", out_buf as i64);
+    trace_num("  LedgerEntryType:", out_buf as i64);
 
     let mut out_buf = [0u8; 32];
     let out_len = unsafe {
         get_ledger_obj_field(slot, MessageKey, out_buf.as_mut_ptr(), out_buf.len()) as usize
     };
-    let _ = trace_data("  MessageKey:", &out_buf[0..out_len], DataRepr::AsHex);
+    trace_data("  MessageKey:", &out_buf[0..out_len], DataRepr::AsHex);
 
     let mut out_buf = 0i32;
     let out_len = unsafe {
         get_ledger_obj_field(slot, OwnerCount, (&mut out_buf) as *mut i32 as *mut u8, 4) as usize
     };
-    let _ = trace_num("  OwnerCount:", out_buf as i64);
+    trace_num("  OwnerCount:", out_buf as i64);
 
     let mut out_buf = [0u8; 32];
     let out_len = unsafe {
         get_ledger_obj_field(slot, PreviousTxnID, out_buf.as_mut_ptr(), out_buf.len()) as usize
     };
-    let _ = trace_data("  PreviousTxnID:", &out_buf[0..out_len], DataRepr::AsHex);
+    trace_data("  PreviousTxnID:", &out_buf[0..out_len], DataRepr::AsHex);
 
     let mut out_buf = 0i32;
     let out_len = unsafe {
@@ -106,44 +106,44 @@ fn test_account_root() {
             4,
         ) as usize
     };
-    let _ = trace_num("  PreviousTxnLgrSeq:", out_buf as i64);
+    trace_num("  PreviousTxnLgrSeq:", out_buf as i64);
 
     let mut out_buf = [0u8; 20];
     let out_len = unsafe {
         get_ledger_obj_field(slot, RegularKey, out_buf.as_mut_ptr(), out_buf.len()) as usize
     };
-    let _ = trace_account_buf("  RegularKey:", &out_buf);
+    trace_account_buf("  RegularKey:", &out_buf);
 
     let mut out_buf = 0i32;
     let out_len = unsafe {
         get_ledger_obj_field(slot, Sequence, (&mut out_buf) as *mut i32 as *mut u8, 4) as usize
     };
-    let _ = trace_num("  Sequence:", out_buf as i64);
+    trace_num("  Sequence:", out_buf as i64);
 
     let mut out_buf = 0i32;
     let out_len = unsafe {
         get_ledger_obj_field(slot, TicketCount, (&mut out_buf) as *mut i32 as *mut u8, 4) as usize
     };
-    let _ = trace_num("  TicketCount:", out_buf as i64);
+    trace_num("  TicketCount:", out_buf as i64);
 
     let mut out_buf = 0i64;
     let out_len = unsafe {
         get_ledger_obj_field(slot, TransferRate, (&mut out_buf) as *mut i64 as *mut u8, 4) as usize
     };
-    let _ = trace_num("  TransferRate:", out_buf);
+    trace_num("  TransferRate:", out_buf);
 
     //TODO urlgravatar is not an sfield, double check
 }
 
 fn test_amendments() {
-    let _ = trace("\n$$$ test_amendments $$$");
+    trace("\n$$$ test_amendments $$$");
     let keylet =
         decode_hex_32(b"7DB0788C020F02780A673DC74757F23823FA3014C1866E72CC4CD8B226CD6EF4").unwrap();
 
     let slot = unsafe { cache_ledger_obj(keylet.as_ptr(), keylet.len(), 0) };
 
     let array_len = unsafe { get_ledger_obj_array_len(slot, sfield::Amendments) };
-    let _ = trace_num("  Amendments array len:", array_len as i64);
+    trace_num("  Amendments array len:", array_len as i64);
     for i in 0..if array_len > 2 { 2 } else { array_len } {
         let mut buf = [0x00; 32];
         let mut locator = Locator::new();
@@ -158,7 +158,7 @@ fn test_amendments() {
                 buf.len(),
             )
         };
-        let _ = trace_data("  Amendment:", &buf[..output_len as usize], DataRepr::AsHex);
+        trace_data("  Amendment:", &buf[..output_len as usize], DataRepr::AsHex);
     }
 
     let mut out_buf = 0i16;
@@ -170,7 +170,7 @@ fn test_amendments() {
             2,
         ) as usize
     };
-    let _ = trace_num("  LedgerEntryType:", out_buf as i64);
+    trace_num("  LedgerEntryType:", out_buf as i64);
 
     let mut buf = [0x00; 32];
     let mut locator = Locator::new();
@@ -187,7 +187,7 @@ fn test_amendments() {
             buf.len(),
         )
     };
-    let _ = trace_data(
+    trace_data(
         "  Majority Amendment:",
         &buf[..output_len as usize],
         DataRepr::AsHex,
@@ -204,11 +204,11 @@ fn test_amendments() {
             4,
         ) as usize
     };
-    let _ = trace_num("  Majority CloseTime:", out_buf);
+    trace_num("  Majority CloseTime:", out_buf);
 }
 
 fn test_amm() {
-    let _ = trace("\n$$$ test_amm $$$");
+    trace("\n$$$ test_amm $$$");
 
     let keylet =
         decode_hex_32(b"97DD92D4F3A791254A530BA769F6669DEBF6B2FC8CCA46842B9031ADCD4D1ADA").unwrap();
@@ -218,7 +218,7 @@ fn test_amm() {
     let mut buf = [0x00; 48];
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::LPTokenBalance, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data(
+    trace_data(
         "  get LPTokenBalance:",
         &buf[..output_len as usize],
         DataRepr::AsHex,
@@ -236,7 +236,7 @@ fn test_amm() {
             buf.len(),
         )
     };
-    let _ = trace_data(
+    trace_data(
         "  AuctionSlot Price:",
         &buf[..output_len as usize],
         DataRepr::AsHex,
@@ -244,7 +244,7 @@ fn test_amm() {
 }
 
 fn test_check() {
-    let _ = trace("\n$$$ test_check $$$");
+    trace("\n$$$ test_check $$$");
     let (slot, keylet) =
         get_slot(b"F23D83EA49474537F7A15EF79DD140DEAE2CD0F4BF2D6383979C863100F9660F");
     let acc = get_account(slot, Account);
@@ -253,12 +253,12 @@ fn test_check() {
     let sqn_len = unsafe {
         get_ledger_obj_field(slot, Sequence, (&mut sqn_buf) as *mut i32 as *mut u8, 4) as usize
     };
-    let _ = trace_num("  Sequence:", sqn_buf as i64);
+    trace_num("  Sequence:", sqn_buf as i64);
     process_keylet_result(check_keylet(&acc, sqn_buf), keylet);
 }
 
 fn test_credential() {
-    let _ = trace("\n$$$ test_credential $$$");
+    trace("\n$$$ test_credential $$$");
     let (slot, keylet) =
         get_slot(b"DC2FCCBB773244E981576CF509E2463B435F5B46F3EF4684E2ED2EC9C575A110");
     let slot = unsafe { cache_ledger_obj(keylet.as_ptr(), keylet.len(), 0) };
@@ -274,7 +274,7 @@ fn test_credential() {
             cred_type_buf.len(),
         ) as usize
     };
-    let _ = trace_data("  CredentialType:", &cred_type_buf[0..len], DataRepr::AsHex);
+    trace_data("  CredentialType:", &cred_type_buf[0..len], DataRepr::AsHex);
 
     process_keylet_result(
         credential_keylet(&subj, &iss, &cred_type_buf[0..len]),
@@ -283,7 +283,7 @@ fn test_credential() {
 }
 
 fn test_delegate() {
-    let _ = trace("\n$$$ test_delegate $$$");
+    trace("\n$$$ test_delegate $$$");
     let (slot, keylet) =
         get_slot(b"572E861CF66227EC90CE789014531EE3336D28C411BA8E18F660B65F1BE68B49");
     let acc = get_account(slot, Account);
@@ -292,7 +292,7 @@ fn test_delegate() {
 }
 
 fn test_deposit_preauth() {
-    let _ = trace("\n$$$ test_deposit_preauth $$$");
+    trace("\n$$$ test_deposit_preauth $$$");
     let (slot, keylet) =
         get_slot(b"A43898B685C450DE8E194B24D9D54E62530536A770CCB311BFEE15A27381ABB2");
     let acc = get_account(slot, Account);
@@ -301,7 +301,7 @@ fn test_deposit_preauth() {
 }
 
 fn test_did() {
-    let _ = trace("\n$$$ test_did $$$");
+    trace("\n$$$ test_did $$$");
     let (slot, keylet) =
         get_slot(b"C3535E58FC564D3B4FBD67DDEA367ABA5C6A97901E7D14F1A316AA492E999D92");
     let acc = get_account(slot, Account);
@@ -309,7 +309,7 @@ fn test_did() {
 }
 
 fn test_escrow() {
-    let _ = trace("\n$$$ test_escrow $$$");
+    trace("\n$$$ test_escrow $$$");
     let (slot, keylet) =
         get_slot(b"41CF1FD65F1A10642BB9ED3258B36B130D9C6EB12B2175A6F3137665AF12B9FD");
     let acc = get_account(slot, Account);
@@ -318,7 +318,7 @@ fn test_escrow() {
 }
 
 fn test_issue() {
-    let _ = trace("\n$$$ test_issue $$$");
+    trace("\n$$$ test_issue $$$");
 
     let keylet =
         decode_hex_32(b"4444444444444444444444444444444444444444444444444444444444444444").unwrap();
@@ -328,13 +328,13 @@ fn test_issue() {
     let mut buf = [0x00; 20];
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::Asset, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data("  XRP Asset:", &buf[..output_len as usize], DataRepr::AsHex);
+    trace_data("  XRP Asset:", &buf[..output_len as usize], DataRepr::AsHex);
 
     // MPT
     let mut buf = [0x00; 24];
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::Asset2, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data("  MPT Asset:", &buf[..output_len as usize], DataRepr::AsHex);
+    trace_data("  MPT Asset:", &buf[..output_len as usize], DataRepr::AsHex);
 
     let keylet =
         decode_hex_32(b"97DD92D4F3A791254A530BA769F6669DEBF6B2FC8CCA46842B9031ADCD4D1ADA").unwrap();
@@ -344,11 +344,11 @@ fn test_issue() {
     let mut buf = [0x00; 40];
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::Asset2, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data("  IOU Asset:", &buf[..output_len as usize], DataRepr::AsHex);
+    trace_data("  IOU Asset:", &buf[..output_len as usize], DataRepr::AsHex);
 }
 
 fn test_line() {
-    let _ = trace("\n$$$ test_line $$$");
+    trace("\n$$$ test_line $$$");
     let (slot, keylet) =
         get_slot(b"E5B2858F0D15ECB4622E7C613285CA0E84BF7209466A5D1FAA6606B7E6DAAA72");
     let slot = unsafe { cache_ledger_obj(keylet.as_ptr(), keylet.len(), 0) };
@@ -356,18 +356,18 @@ fn test_line() {
     let mut buf = [0x00; 48];
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::LowLimit, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data("  LowLimit:", &buf[..output_len as usize], DataRepr::AsHex);
+    trace_data("  LowLimit:", &buf[..output_len as usize], DataRepr::AsHex);
     let data: [u8; 20] = buf[28..48].try_into().unwrap();
     let acc1 = AccountID::from(data);
 
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::HighLimit, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data("  HighLimit:", &buf[..output_len as usize], DataRepr::AsHex);
+    trace_data("  HighLimit:", &buf[..output_len as usize], DataRepr::AsHex);
     let data: [u8; 20] = buf[28..48].try_into().unwrap();
     let acc2 = AccountID::from(data);
 
     let output_len = unsafe { get_ledger_obj_field(slot, Balance, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data("  Balance:", &buf[..output_len as usize], DataRepr::AsHex);
+    trace_data("  Balance:", &buf[..output_len as usize], DataRepr::AsHex);
     let data: [u8; 20] = buf[8..28].try_into().unwrap();
     let currency = CurrencyCode::from(data);
 
@@ -375,7 +375,7 @@ fn test_line() {
 }
 
 fn test_mpt_amount() {
-    let _ = trace("\n$$$ test_mpt_amount, access an MPT Amount $$$");
+    trace("\n$$$ test_mpt_amount, access an MPT Amount $$$");
 
     let keylet =
         decode_hex_32(b"4444444444444444444444444444444444444444444444444444444444444444").unwrap();
@@ -385,7 +385,7 @@ fn test_mpt_amount() {
     let mut buf = [0x00; 48];
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::Amount2, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data(
+    trace_data(
         "  MPT Amount2:",
         &buf[..output_len as usize],
         DataRepr::AsHex,
@@ -393,7 +393,7 @@ fn test_mpt_amount() {
 }
 
 fn test_mpt_fields() {
-    let _ = trace("\n$$$ test_mpt_fields, access individual fields $$$");
+    trace("\n$$$ test_mpt_fields, access individual fields $$$");
 
     let keylet =
         decode_hex_32(b"22F99DCD55BCCF3D68DC3E4D6CF12602006A7563A6BE93FC57FD63298BCCEB13").unwrap();
@@ -404,7 +404,7 @@ fn test_mpt_fields() {
     let output_len = unsafe {
         get_ledger_obj_field(slot, sfield::MPTokenIssuanceID, buf.as_mut_ptr(), buf.len())
     };
-    let _ = trace_data(
+    trace_data(
         "  MPTokenIssuanceID:",
         &buf[..output_len as usize],
         DataRepr::AsHex,
@@ -419,11 +419,11 @@ fn test_mpt_fields() {
             8,
         )
     };
-    let _ = trace_num("  MPTAmount:", value as i64);
+    trace_num("  MPTAmount:", value as i64);
 }
 
 fn test_nft_offer() {
-    let _ = trace("\n$$$ test_nft_offer $$$");
+    trace("\n$$$ test_nft_offer $$$");
     let (slot, keylet) =
         get_slot(b"E7DB3BE2E00EA4BFD61B43B96D96EF627823A0C093F14A95E3AD68708B63696B");
     let acc = get_account(slot, sfield::Owner);
@@ -432,14 +432,14 @@ fn test_nft_offer() {
 }
 
 fn test_offer() {
-    let _ = trace("\n$$$ test_offer $$$");
+    trace("\n$$$ test_offer $$$");
     let (slot, keylet) =
         get_slot(b"D0A063DEE0B0EC9522CF35CD55771B5DCAFA19A133EE46A0295E4D089AF86438");
 
     let mut buf = [0x00; 48];
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::TakerPays, buf.as_mut_ptr(), buf.len()) };
-    let _ = trace_data("  TakerPays:", &buf[..output_len as usize], DataRepr::AsHex);
+    trace_data("  TakerPays:", &buf[..output_len as usize], DataRepr::AsHex);
 
     let acc = get_account(slot, Account);
 
@@ -447,13 +447,13 @@ fn test_offer() {
     let sqn_len = unsafe {
         get_ledger_obj_field(slot, Sequence, (&mut sqn_buf) as *mut i32 as *mut u8, 4) as usize
     };
-    let _ = trace_num("  Sequence:", sqn_buf as i64);
+    trace_num("  Sequence:", sqn_buf as i64);
 
     process_keylet_result(offer_keylet(&acc, sqn_buf), keylet);
 }
 
 fn test_oracle() {
-    let _ = trace("\n$$$ test_oracle $$$");
+    trace("\n$$$ test_oracle $$$");
     let (slot, keylet) =
         get_slot(b"FB0D2E2B5C7240772C2D2A3E7B99BF44EA955C7C4977A368F704FE879F0E0612");
     let acc = get_account(slot, sfield::Owner);
@@ -462,7 +462,7 @@ fn test_oracle() {
 }
 
 fn test_pay_channel() {
-    let _ = trace("\n$$$ test_pay_channel $$$");
+    trace("\n$$$ test_pay_channel $$$");
     let (slot, keylet) =
         get_slot(b"C7F634794B79DB40E87179A9D1BF05D05797AE7E92DF8E93FD6656E8C4BE3AE7");
     let acc = get_account(slot, Account);
@@ -472,14 +472,14 @@ fn test_pay_channel() {
 }
 
 fn test_signers() {
-    let _ = trace("\n$$$ test_signers $$$");
+    trace("\n$$$ test_signers $$$");
     let (_, keylet) = get_slot(b"A6D94867F6EA7D78BDD941DB2A57E4797288EAE5BB93423FA10F8602577B0504");
     let acc = AccountID::from(decode_hex_20(b"7AED8B5479456A3491033E9EC80879CDA5104AD6").unwrap());
     process_keylet_result(signers_keylet(&acc), keylet);
 }
 
 fn test_ticket() {
-    let _ = trace("\n$$$ test_ticket $$$");
+    trace("\n$$$ test_ticket $$$");
     let (slot, keylet) =
         get_slot(b"B603682BC36F474F708E1A150B7C034C6C13D838C3F2F135CDB7BEA6E5B5ACEF");
     let acc = get_account(slot, Account);
@@ -493,7 +493,7 @@ fn test_ticket() {
             4,
         ) as usize
     };
-    let _ = trace_num("  TicketSequence:", sqn_buf as i64);
+    trace_num("  TicketSequence:", sqn_buf as i64);
     process_keylet_result(ticket_keylet(&acc, sqn_buf), keylet);
 }
 
@@ -509,7 +509,7 @@ fn get_account(slot: i32, field: i32) -> AccountID {
     let mut acc_buf = [0u8; 20];
     let acc_len =
         unsafe { get_ledger_obj_field(slot, field, acc_buf.as_mut_ptr(), acc_buf.len()) as usize };
-    let _ = trace_account_buf("  accountID:", &acc_buf);
+    trace_account_buf("  accountID:", &acc_buf);
     AccountID::from(acc_buf)
 }
 
@@ -517,15 +517,15 @@ fn process_keylet_result(result: host::Result<KeyletBytes>, expected: [u8; 32]) 
     match result {
         host::Result::Ok(computed_keylet) => {
             if computed_keylet == expected {
-                let _ = trace("  keylet match");
+                trace("  keylet match");
             } else {
-                let _ = trace("  keylet doesn't match: ");
-                let _ = trace_data("    computed:", &computed_keylet[..], DataRepr::AsHex);
-                let _ = trace_data("    expected:", &expected[..], DataRepr::AsHex);
+                trace("  keylet doesn't match: ");
+                trace_data("    computed:", &computed_keylet[..], DataRepr::AsHex);
+                trace_data("    expected:", &expected[..], DataRepr::AsHex);
             }
         }
         host::Result::Err(_) => {
-            let _ = trace("  keylet function error");
+            trace("  keylet function error");
         }
     }
 }

--- a/projects/e2e-tests/float_tests/src/lib.rs
+++ b/projects/e2e-tests/float_tests/src/lib.rs
@@ -23,7 +23,7 @@ use xrpl_wasm_std::sfield::{
 };
 
 fn test_float_from_host() {
-    let _ = trace("\n$$$ test_float_from_host $$$");
+    trace("\n$$$ test_float_from_host $$$");
 
     let keylet =
         decode_hex_32(b"97DD92D4F3A791254A530BA769F6669DEBF6B2FC8CCA46842B9031ADCD4D1ADA").unwrap();
@@ -32,7 +32,7 @@ fn test_float_from_host() {
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::LPTokenBalance, buf.as_mut_ptr(), buf.len()) };
     let f_lptokenbalance: [u8; 8] = buf[0..8].try_into().unwrap();
-    let _ = trace_float("  LPTokenBalance value:", &f_lptokenbalance);
+    trace_float("  LPTokenBalance value:", &f_lptokenbalance);
 
     let mut locator = Locator::new();
     locator.pack(sfield::AuctionSlot);
@@ -47,7 +47,7 @@ fn test_float_from_host() {
         )
     };
     let f_auctionslot: [u8; 8] = buf[0..8].try_into().unwrap();
-    let _ = trace_float("  AuctionSlot Price value:", &f_auctionslot);
+    trace_float("  AuctionSlot Price value:", &f_auctionslot);
 
     let keylet =
         decode_hex_32(b"D0A063DEE0B0EC9522CF35CD55771B5DCAFA19A133EE46A0295E4D089AF86438").unwrap();
@@ -56,18 +56,18 @@ fn test_float_from_host() {
     let output_len =
         unsafe { get_ledger_obj_field(slot, sfield::TakerPays, buf.as_mut_ptr(), buf.len()) };
     let f_takerpays: [u8; 8] = buf[0..8].try_into().unwrap();
-    let _ = trace_float("  TakerPays:", &f_takerpays);
+    trace_float("  TakerPays:", &f_takerpays);
 }
 
 fn test_float_from_wasm() {
-    let _ = trace("\n$$$ test_float_from_wasm $$$");
+    trace("\n$$$ test_float_from_wasm $$$");
 
     let mut f: [u8; 8] = [0u8; 8];
     if 8 == unsafe { float_from_int(12300, f.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
-        let _ = trace_float("  float from i64 12300:", &f);
-        let _ = trace_data("  float from i64 12300 as HEX:", &f, AsHex);
+        trace_float("  float from i64 12300:", &f);
+        trace_data("  float from i64 12300 as HEX:", &f, AsHex);
     } else {
-        let _ = trace("  float from i64 12300: failed");
+        trace("  float from i64 12300: failed");
     }
 
     let u64_value: u64 = 12300;
@@ -80,52 +80,52 @@ fn test_float_from_wasm() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     } {
-        let _ = trace_float("  float from u64 12300:", &f);
+        trace_float("  float from u64 12300:", &f);
     } else {
-        let _ = trace("  float from u64 12300: failed");
+        trace("  float from u64 12300: failed");
     }
 
     if 8 == unsafe { float_set(2, 123, f.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
-        let _ = trace_float("  float from exp 2, mantissa 123:", &f);
+        trace_float("  float from exp 2, mantissa 123:", &f);
     } else {
-        let _ = trace("  float from exp 2, mantissa 3: failed");
+        trace("  float from exp 2, mantissa 3: failed");
     }
 
-    let _ = trace_float("  float from const 1:", &FLOAT_ONE);
-    let _ = trace_float("  float from const -1:", &FLOAT_NEGATIVE_ONE);
+    trace_float("  float from const 1:", &FLOAT_ONE);
+    trace_float("  float from const -1:", &FLOAT_NEGATIVE_ONE);
 }
 
 fn test_float_compare() {
-    let _ = trace("\n$$$ test_float_compare $$$");
+    trace("\n$$$ test_float_compare $$$");
 
     let mut f1: [u8; 8] = [0u8; 8];
     if 8 != unsafe { float_from_int(1, f1.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
-        let _ = trace("  float from 1: failed");
+        trace("  float from 1: failed");
     } else {
-        let _ = trace_float("  float from 1:", &f1);
+        trace_float("  float from 1:", &f1);
     }
 
     if 0 == unsafe { float_compare(f1.as_ptr(), 8, FLOAT_ONE.as_ptr(), 8) } {
-        let _ = trace("  float from 1 == FLOAT_ONE");
+        trace("  float from 1 == FLOAT_ONE");
     } else {
-        let _ = trace("  float from 1 != FLOAT_ONE");
+        trace("  float from 1 != FLOAT_ONE");
     }
 
     if 1 == unsafe { float_compare(f1.as_ptr(), 8, FLOAT_NEGATIVE_ONE.as_ptr(), 8) } {
-        let _ = trace("  float from 1 > FLOAT_NEGATIVE_ONE");
+        trace("  float from 1 > FLOAT_NEGATIVE_ONE");
     } else {
-        let _ = trace("  float from 1 !> FLOAT_NEGATIVE_ONE");
+        trace("  float from 1 !> FLOAT_NEGATIVE_ONE");
     }
 
     if 2 == unsafe { float_compare(FLOAT_NEGATIVE_ONE.as_ptr(), 8, f1.as_ptr(), 8) } {
-        let _ = trace("  FLOAT_NEGATIVE_ONE < float from 1");
+        trace("  FLOAT_NEGATIVE_ONE < float from 1");
     } else {
-        let _ = trace("  FLOAT_NEGATIVE_ONE !< float from 1");
+        trace("  FLOAT_NEGATIVE_ONE !< float from 1");
     }
 }
 
 fn test_float_add_subtract() {
-    let _ = trace("\n$$$ test_float_add_subtract $$$");
+    trace("\n$$$ test_float_add_subtract $$$");
 
     let mut f_compute: [u8; 8] = FLOAT_ONE;
     for i in 0..9 {
@@ -140,16 +140,16 @@ fn test_float_add_subtract() {
                 FLOAT_ROUNDING_MODES_TO_NEAREST,
             )
         };
-        // let _ = trace_float("  float:", &f_compute);
+        // trace_float("  float:", &f_compute);
     }
     let mut f10: [u8; 8] = [0u8; 8];
     if 8 != unsafe { float_from_int(10, f10.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) } {
-        // let _ = trace("  float from 10: failed");
+        // trace("  float from 10: failed");
     }
     if 0 == unsafe { float_compare(f10.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  repeated add: good");
+        trace("  repeated add: good");
     } else {
-        let _ = trace("  repeated add: bad");
+        trace("  repeated add: bad");
     }
 
     for i in 0..11 {
@@ -166,14 +166,14 @@ fn test_float_add_subtract() {
         };
     }
     if 0 == unsafe { float_compare(f_compute.as_ptr(), 8, FLOAT_NEGATIVE_ONE.as_ptr(), 8) } {
-        let _ = trace("  repeated subtract: good");
+        trace("  repeated subtract: good");
     } else {
-        let _ = trace("  repeated subtract: bad");
+        trace("  repeated subtract: bad");
     }
 }
 
 fn test_float_multiply_divide() {
-    let _ = trace("\n$$$ test_float_multiply_divide $$$");
+    trace("\n$$$ test_float_multiply_divide $$$");
 
     let mut f10: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(10, f10.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) };
@@ -190,7 +190,7 @@ fn test_float_multiply_divide() {
                 FLOAT_ROUNDING_MODES_TO_NEAREST,
             )
         };
-        // let _ = trace_float("  float:", &f_compute);
+        // trace_float("  float:", &f_compute);
     }
     let mut f1000000: [u8; 8] = [0u8; 8];
     unsafe {
@@ -203,9 +203,9 @@ fn test_float_multiply_divide() {
     };
 
     if 0 == unsafe { float_compare(f1000000.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  repeated multiply: good");
+        trace("  repeated multiply: good");
     } else {
-        let _ = trace("  repeated multiply: bad");
+        trace("  repeated multiply: bad");
     }
 
     for i in 0..7 {
@@ -225,14 +225,14 @@ fn test_float_multiply_divide() {
     unsafe { float_set(-1, 1, f01.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) };
 
     if 0 == unsafe { float_compare(f_compute.as_ptr(), 8, f01.as_ptr(), 8) } {
-        let _ = trace("  repeated divide: good");
+        trace("  repeated divide: good");
     } else {
-        let _ = trace("  repeated divide: bad");
+        trace("  repeated divide: bad");
     }
 }
 
 fn test_float_pow() {
-    let _ = trace("\n$$$ test_float_pow $$$");
+    trace("\n$$$ test_float_pow $$$");
 
     let mut f_compute: [u8; 8] = [0u8; 8];
     unsafe {
@@ -245,7 +245,7 @@ fn test_float_pow() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float cube of 1:", &f_compute);
+    trace_float("  float cube of 1:", &f_compute);
 
     unsafe {
         float_pow(
@@ -257,7 +257,7 @@ fn test_float_pow() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float 6th power of -1:", &f_compute);
+    trace_float("  float 6th power of -1:", &f_compute);
 
     let mut f9: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(9, f9.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) };
@@ -271,7 +271,7 @@ fn test_float_pow() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float square of 9:", &f_compute);
+    trace_float("  float square of 9:", &f_compute);
 
     unsafe {
         float_pow(
@@ -283,7 +283,7 @@ fn test_float_pow() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float 0th power of 9:", &f_compute);
+    trace_float("  float 0th power of 9:", &f_compute);
 
     let mut f0: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(0, f0.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) };
@@ -297,7 +297,7 @@ fn test_float_pow() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float square of 0:", &f_compute);
+    trace_float("  float square of 0:", &f_compute);
 
     let r = unsafe {
         float_pow(
@@ -309,14 +309,14 @@ fn test_float_pow() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_num(
+    trace_num(
         "  float 0th power of 0 (expecting INVALID_PARAMS error):",
         r as i64,
     );
 }
 
 fn test_float_root() {
-    let _ = trace("\n$$$ test_float_root $$$");
+    trace("\n$$$ test_float_root $$$");
 
     let mut f9: [u8; 8] = [0u8; 8];
     unsafe { float_from_int(9, f9.as_mut_ptr(), 8, FLOAT_ROUNDING_MODES_TO_NEAREST) };
@@ -331,7 +331,7 @@ fn test_float_root() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float sqrt of 9:", &f_compute);
+    trace_float("  float sqrt of 9:", &f_compute);
     unsafe {
         float_root(
             f9.as_ptr(),
@@ -342,7 +342,7 @@ fn test_float_root() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float cbrt of 9:", &f_compute);
+    trace_float("  float cbrt of 9:", &f_compute);
 
     let mut f1000000: [u8; 8] = [0u8; 8];
     unsafe {
@@ -363,7 +363,7 @@ fn test_float_root() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float cbrt of 1000000:", &f_compute);
+    trace_float("  float cbrt of 1000000:", &f_compute);
     unsafe {
         float_root(
             f1000000.as_ptr(),
@@ -374,11 +374,11 @@ fn test_float_root() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  float 6th root of 1000000:", &f_compute);
+    trace_float("  float 6th root of 1000000:", &f_compute);
 }
 
 fn test_float_log() {
-    let _ = trace("\n$$$ test_float_log $$$");
+    trace("\n$$$ test_float_log $$$");
 
     let mut f1000000: [u8; 8] = [0u8; 8];
     unsafe {
@@ -399,11 +399,11 @@ fn test_float_log() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  log_10 of 1000000:", &f_compute);
+    trace_float("  log_10 of 1000000:", &f_compute);
 }
 
 fn test_float_negate() {
-    let _ = trace("\n$$$ test_float_negate $$$");
+    trace("\n$$$ test_float_negate $$$");
 
     let mut f_compute: [u8; 8] = [0u8; 8];
     unsafe {
@@ -417,11 +417,11 @@ fn test_float_negate() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    // let _ = trace_float("  float:", &f_compute);
+    // trace_float("  float:", &f_compute);
     if 0 == unsafe { float_compare(FLOAT_NEGATIVE_ONE.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  negate const 1: good");
+        trace("  negate const 1: good");
     } else {
-        let _ = trace("  negate const 1: bad");
+        trace("  negate const 1: bad");
     }
 
     unsafe {
@@ -435,16 +435,16 @@ fn test_float_negate() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    // let _ = trace_float("  float:", &f_compute);
+    // trace_float("  float:", &f_compute);
     if 0 == unsafe { float_compare(FLOAT_ONE.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  negate const -1: good");
+        trace("  negate const -1: good");
     } else {
-        let _ = trace("  negate const -1: bad");
+        trace("  negate const -1: bad");
     }
 }
 
 fn test_float_invert() {
-    let _ = trace("\n$$$ test_float_invert $$$");
+    trace("\n$$$ test_float_invert $$$");
 
     let mut f_compute: [u8; 8] = [0u8; 8];
     let mut f10: [u8; 8] = [0u8; 8];
@@ -460,7 +460,7 @@ fn test_float_invert() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  invert a float from 10:", &f_compute);
+    trace_float("  invert a float from 10:", &f_compute);
     unsafe {
         float_divide(
             FLOAT_ONE.as_ptr(),
@@ -472,13 +472,13 @@ fn test_float_invert() {
             FLOAT_ROUNDING_MODES_TO_NEAREST,
         )
     };
-    let _ = trace_float("  invert again:", &f_compute);
+    trace_float("  invert again:", &f_compute);
 
     // if f10's value is 7, then invert twice won't match the original value
     if 0 == unsafe { float_compare(f10.as_ptr(), 8, f_compute.as_ptr(), 8) } {
-        let _ = trace("  invert twice: good");
+        trace("  invert twice: good");
     } else {
-        let _ = trace("  invert twice: bad");
+        trace("  invert twice: bad");
     }
 }
 

--- a/projects/e2e-tests/host_functions_test/src/lib.rs
+++ b/projects/e2e-tests/host_functions_test/src/lib.rs
@@ -28,13 +28,13 @@ extern crate std;
 use xrpl_wasm_std::core::current_tx::escrow_finish::EscrowFinish;
 use xrpl_wasm_std::core::current_tx::traits::TransactionCommonFields;
 use xrpl_wasm_std::host;
-use xrpl_wasm_std::host::trace::{DataRepr, trace, trace_account_buf, trace_data, trace_num};
+use xrpl_wasm_std::host::trace::{DataRepr, trace, trace_account_buf, trace_data, trace_num, trace_num_with_result};
 use xrpl_wasm_std::sfield;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn finish() -> i32 {
-    let _ = trace("=== HOST FUNCTIONS TEST ===");
-    let _ = trace("Testing 26 host functions");
+    trace("=== HOST FUNCTIONS TEST ===");
+    trace("Testing 26 host functions");
 
     // Category 1: Ledger Header Data Functions (3 functions)
     // Error range: -100 to -199
@@ -85,7 +85,7 @@ pub extern "C" fn finish() -> i32 {
         err => return err,
     }
 
-    let _ = trace("SUCCESS: All host function tests passed!");
+    trace("SUCCESS: All host function tests passed!");
     1 // Success return code for WASM finish function
 }
 
@@ -94,25 +94,25 @@ pub extern "C" fn finish() -> i32 {
 /// - get_parent_ledger_time() - Get parent ledger timestamp
 /// - get_parent_ledger_hash() - Get parent ledger hash
 fn test_ledger_header_functions() -> i32 {
-    let _ = trace("--- Category 1: Ledger Header Functions ---");
+    trace("--- Category 1: Ledger Header Functions ---");
 
     // Test 1.1: get_ledger_sqn() - should return current ledger sequence number
     let sqn_result = unsafe { host::get_ledger_sqn() };
 
     if sqn_result <= 0 {
-        let _ = trace_num("ERROR: get_ledger_sqn failed:", sqn_result as i64);
+        trace_num("ERROR: get_ledger_sqn failed:", sqn_result as i64);
         return -101; // Ledger sequence number test failed
     }
-    let _ = trace_num("Ledger sequence number:", sqn_result as i64);
+    trace_num("Ledger sequence number:", sqn_result as i64);
 
     // Test 1.2: get_parent_ledger_time() - should return parent ledger timestamp
     let time_result = unsafe { host::get_parent_ledger_time() };
 
     if time_result <= 0 {
-        let _ = trace_num("ERROR: get_parent_ledger_time failed:", time_result as i64);
+        trace_num("ERROR: get_parent_ledger_time failed:", time_result as i64);
         return -102; // Parent ledger time test failed
     }
-    let _ = trace_num("Parent ledger time:", time_result as i64);
+    trace_num("Parent ledger time:", time_result as i64);
 
     // Test 1.3: get_parent_ledger_hash() - should return parent ledger hash (32 bytes)
     let mut hash_buffer = [0u8; 32];
@@ -120,22 +120,22 @@ fn test_ledger_header_functions() -> i32 {
         unsafe { host::get_parent_ledger_hash(hash_buffer.as_mut_ptr(), hash_buffer.len()) };
 
     if hash_result != 32 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: get_parent_ledger_hash wrong length:",
             hash_result as i64,
         );
         return -103; // Parent ledger hash test failed - should be exactly 32 bytes
     }
-    let _ = trace_data("Parent ledger hash:", &hash_buffer, DataRepr::AsHex);
+    trace_data("Parent ledger hash:", &hash_buffer, DataRepr::AsHex);
 
-    let _ = trace("SUCCESS: Ledger header functions");
+    trace("SUCCESS: Ledger header functions");
     0
 }
 
 /// Test Category 2: Transaction Data Functions (5 functions)
 /// Tests all functions for accessing current transaction data
 fn test_transaction_data_functions() -> i32 {
-    let _ = trace("--- Category 2: Transaction Data Functions ---");
+    trace("--- Category 2: Transaction Data Functions ---");
 
     // Test 2.1: get_tx_field() - Basic transaction field access
     // Test with Account field (required, 20 bytes)
@@ -149,13 +149,13 @@ fn test_transaction_data_functions() -> i32 {
     };
 
     if account_len != 20 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: get_tx_field(Account) wrong length:",
             account_len as i64,
         );
         return -201; // Basic transaction field test failed
     }
-    let _ = trace_account_buf("Transaction Account:", &account_buffer);
+    trace_account_buf("Transaction Account:", &account_buffer);
 
     // Test with Fee field (XRP amount - 8 bytes in new serialized format)
     // New format: XRP amounts are always 8 bytes (positive: value | cPositive flag, negative: just value)
@@ -164,14 +164,14 @@ fn test_transaction_data_functions() -> i32 {
         unsafe { host::get_tx_field(sfield::Fee, fee_buffer.as_mut_ptr(), fee_buffer.len()) };
 
     if fee_len != 8 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: get_tx_field(Fee) wrong length (expected 8 bytes for XRP):",
             fee_len as i64,
         );
         return -202; // Fee field test failed - XRP amounts should be exactly 8 bytes
     }
-    let _ = trace_num("Transaction Fee length:", fee_len as i64);
-    let _ = trace_data(
+    trace_num("Transaction Fee length:", fee_len as i64);
+    trace_data(
         "Transaction Fee (serialized XRP amount):",
         &fee_buffer,
         DataRepr::AsHex,
@@ -183,13 +183,13 @@ fn test_transaction_data_functions() -> i32 {
         unsafe { host::get_tx_field(sfield::Sequence, seq_buffer.as_mut_ptr(), seq_buffer.len()) };
 
     if seq_len != 4 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: get_tx_field(Sequence) wrong length:",
             seq_len as i64,
         );
         return -203; // Sequence field test failed
     }
-    let _ = trace_data("Transaction Sequence:", &seq_buffer, DataRepr::AsHex);
+    trace_data("Transaction Sequence:", &seq_buffer, DataRepr::AsHex);
 
     // NOTE: get_tx_field2() through get_tx_field6() have been deprecated.
     // Use get_tx_field() with appropriate parameters for all transaction field access.
@@ -207,14 +207,14 @@ fn test_transaction_data_functions() -> i32 {
     };
 
     if nested_result < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_tx_nested_field not applicable:",
             nested_result as i64,
         );
         // Expected - locator may not match transaction structure
     } else {
-        let _ = trace_num("Nested field length:", nested_result as i64);
-        let _ = trace_data(
+        trace_num("Nested field length:", nested_result as i64);
+        trace_data(
             "Nested field:",
             &nested_buffer[..nested_result as usize],
             DataRepr::AsHex,
@@ -223,32 +223,32 @@ fn test_transaction_data_functions() -> i32 {
 
     // Test 2.3: get_tx_array_len() - Get array length
     let signers_len = unsafe { host::get_tx_array_len(sfield::Signers) };
-    let _ = trace_num("Signers array length:", signers_len as i64);
+    trace_num("Signers array length:", signers_len as i64);
 
     let memos_len = unsafe { host::get_tx_array_len(sfield::Memos) };
-    let _ = trace_num("Memos array length:", memos_len as i64);
+    trace_num("Memos array length:", memos_len as i64);
 
     // Test 2.4: get_tx_nested_array_len() - Get nested array length with locator
     let nested_array_len =
         unsafe { host::get_tx_nested_array_len(locator.as_ptr(), locator.len()) };
 
     if nested_array_len < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_tx_nested_array_len not applicable:",
             nested_array_len as i64,
         );
     } else {
-        let _ = trace_num("Nested array length:", nested_array_len as i64);
+        trace_num("Nested array length:", nested_array_len as i64);
     }
 
-    let _ = trace("SUCCESS: Transaction data functions");
+    trace("SUCCESS: Transaction data functions");
     0
 }
 
 /// Test Category 3: Current Ledger Object Functions (4 functions)
 /// Tests functions that access the current ledger object being processed
 fn test_current_ledger_object_functions() -> i32 {
-    let _ = trace("--- Category 3: Current Ledger Object Functions ---");
+    trace("--- Category 3: Current Ledger Object Functions ---");
 
     // Test 3.1: get_current_ledger_obj_field() - Access field from current ledger object
     // Test with Balance field (XRP amount - 8 bytes in new serialized format)
@@ -262,27 +262,27 @@ fn test_current_ledger_object_functions() -> i32 {
     };
 
     if balance_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_current_ledger_obj_field(Balance) failed (may be expected):",
             balance_result as i64,
         );
         // This might fail if current ledger object doesn't have balance field
     } else if balance_result == 8 {
-        let _ = trace_num(
+        trace_num(
             "Current object balance length (XRP amount):",
             balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Current object balance (serialized XRP amount):",
             &balance_buffer,
             DataRepr::AsHex,
         );
     } else {
-        let _ = trace_num(
+        trace_num(
             "Current object balance length (non-XRP amount):",
             balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Current object balance:",
             &balance_buffer[..balance_result as usize],
             DataRepr::AsHex,
@@ -300,12 +300,12 @@ fn test_current_ledger_object_functions() -> i32 {
     };
 
     if current_account_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_current_ledger_obj_field(Account) failed:",
             current_account_result as i64,
         );
     } else {
-        let _ = trace_account_buf("Current ledger object account:", &current_account_buffer);
+        trace_account_buf("Current ledger object account:", &current_account_buffer);
     }
 
     // Test 3.2: get_current_ledger_obj_nested_field() - Nested field access
@@ -321,13 +321,13 @@ fn test_current_ledger_object_functions() -> i32 {
     };
 
     if current_nested_result < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_current_ledger_obj_nested_field not applicable:",
             current_nested_result as i64,
         );
     } else {
-        let _ = trace_num("Current nested field length:", current_nested_result as i64);
-        let _ = trace_data(
+        trace_num("Current nested field length:", current_nested_result as i64);
+        trace_data(
             "Current nested field:",
             &current_nested_buffer[..current_nested_result as usize],
             DataRepr::AsHex,
@@ -336,7 +336,7 @@ fn test_current_ledger_object_functions() -> i32 {
 
     // Test 3.3: get_current_ledger_obj_array_len() - Array length in current object
     let current_array_len = unsafe { host::get_current_ledger_obj_array_len(sfield::Signers) };
-    let _ = trace_num(
+    trace_num(
         "Current object Signers array length:",
         current_array_len as i64,
     );
@@ -346,25 +346,25 @@ fn test_current_ledger_object_functions() -> i32 {
         unsafe { host::get_current_ledger_obj_nested_array_len(locator.as_ptr(), locator.len()) };
 
     if current_nested_array_len < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_current_ledger_obj_nested_array_len not applicable:",
             current_nested_array_len as i64,
         );
     } else {
-        let _ = trace_num(
+        trace_num(
             "Current nested array length:",
             current_nested_array_len as i64,
         );
     }
 
-    let _ = trace("SUCCESS: Current ledger object functions");
+    trace("SUCCESS: Current ledger object functions");
     0
 }
 
 /// Test Category 4: Any Ledger Object Functions (5 functions)
 /// Tests functions that work with cached ledger objects
 fn test_any_ledger_object_functions() -> i32 {
-    let _ = trace("--- Category 4: Any Ledger Object Functions ---");
+    trace("--- Category 4: Any Ledger Object Functions ---");
 
     // First we need to cache a ledger object to test the other functions
     // Get the account from transaction and generate its keylet
@@ -383,7 +383,7 @@ fn test_any_ledger_object_functions() -> i32 {
     };
 
     if keylet_result != 32 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: account_keylet failed for caching test:",
             keylet_result as i64,
         );
@@ -394,7 +394,7 @@ fn test_any_ledger_object_functions() -> i32 {
         unsafe { host::cache_ledger_obj(keylet_buffer.as_ptr(), keylet_result as usize, 0) };
 
     if cache_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: cache_ledger_obj failed (expected with test fixtures):",
             cache_result as i64,
         );
@@ -414,7 +414,7 @@ fn test_any_ledger_object_functions() -> i32 {
             )
         };
         if field_result < 0 {
-            let _ = trace_num(
+            trace_num(
                 "INFO: get_ledger_obj_field failed as expected (no cached object):",
                 field_result as i64,
             );
@@ -432,7 +432,7 @@ fn test_any_ledger_object_functions() -> i32 {
             )
         };
         if nested_result < 0 {
-            let _ = trace_num(
+            trace_num(
                 "INFO: get_ledger_obj_nested_field failed as expected:",
                 nested_result as i64,
             );
@@ -441,7 +441,7 @@ fn test_any_ledger_object_functions() -> i32 {
         // Test get_ledger_obj_array_len with invalid slot
         let array_result = unsafe { host::get_ledger_obj_array_len(1, sfield::Signers) };
         if array_result < 0 {
-            let _ = trace_num(
+            trace_num(
                 "INFO: get_ledger_obj_array_len failed as expected:",
                 array_result as i64,
             );
@@ -451,19 +451,19 @@ fn test_any_ledger_object_functions() -> i32 {
         let nested_array_result =
             unsafe { host::get_ledger_obj_nested_array_len(1, locator.as_ptr(), locator.len()) };
         if nested_array_result < 0 {
-            let _ = trace_num(
+            trace_num(
                 "INFO: get_ledger_obj_nested_array_len failed as expected:",
                 nested_array_result as i64,
             );
         }
 
-        let _ = trace("SUCCESS: Any ledger object functions (interface tested)");
+        trace("SUCCESS: Any ledger object functions (interface tested)");
         return 0;
     }
 
     // If we successfully cached an object, test the access functions
     let slot = cache_result;
-    let _ = trace_num("Successfully cached object in slot:", slot as i64);
+    trace_num("Successfully cached object in slot:", slot as i64);
 
     // Test 4.2: get_ledger_obj_field() - Access field from cached object
     let mut cached_balance_buffer = [0u8; 8];
@@ -477,26 +477,26 @@ fn test_any_ledger_object_functions() -> i32 {
     };
 
     if cached_balance_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_ledger_obj_field(Balance) failed:",
             cached_balance_result as i64,
         );
     } else if cached_balance_result == 8 {
-        let _ = trace_num(
+        trace_num(
             "Cached object balance length (XRP amount):",
             cached_balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Cached object balance (serialized XRP amount):",
             &cached_balance_buffer,
             DataRepr::AsHex,
         );
     } else {
-        let _ = trace_num(
+        trace_num(
             "Cached object balance length (non-XRP amount):",
             cached_balance_result as i64,
         );
-        let _ = trace_data(
+        trace_data(
             "Cached object balance:",
             &cached_balance_buffer[..cached_balance_result as usize],
             DataRepr::AsHex,
@@ -517,13 +517,13 @@ fn test_any_ledger_object_functions() -> i32 {
     };
 
     if cached_nested_result < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_ledger_obj_nested_field not applicable:",
             cached_nested_result as i64,
         );
     } else {
-        let _ = trace_num("Cached nested field length:", cached_nested_result as i64);
-        let _ = trace_data(
+        trace_num("Cached nested field length:", cached_nested_result as i64);
+        trace_data(
             "Cached nested field:",
             &cached_nested_buffer[..cached_nested_result as usize],
             DataRepr::AsHex,
@@ -532,7 +532,7 @@ fn test_any_ledger_object_functions() -> i32 {
 
     // Test 4.4: get_ledger_obj_array_len() - Array length from cached object
     let cached_array_len = unsafe { host::get_ledger_obj_array_len(slot, sfield::Signers) };
-    let _ = trace_num(
+    trace_num(
         "Cached object Signers array length:",
         cached_array_len as i64,
     );
@@ -542,25 +542,25 @@ fn test_any_ledger_object_functions() -> i32 {
         unsafe { host::get_ledger_obj_nested_array_len(slot, locator.as_ptr(), locator.len()) };
 
     if cached_nested_array_len < 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_ledger_obj_nested_array_len not applicable:",
             cached_nested_array_len as i64,
         );
     } else {
-        let _ = trace_num(
+        trace_num(
             "Cached nested array length:",
             cached_nested_array_len as i64,
         );
     }
 
-    let _ = trace("SUCCESS: Any ledger object functions");
+    trace("SUCCESS: Any ledger object functions");
     0
 }
 
 /// Test Category 5: Keylet Generation Functions (4 functions)
 /// Tests keylet generation functions for different ledger entry types
 fn test_keylet_generation_functions() -> i32 {
-    let _ = trace("--- Category 5: Keylet Generation Functions ---");
+    trace("--- Category 5: Keylet Generation Functions ---");
 
     let escrow_finish = EscrowFinish;
     let account_id = escrow_finish.get_account().unwrap();
@@ -577,13 +577,13 @@ fn test_keylet_generation_functions() -> i32 {
     };
 
     if account_keylet_result != 32 {
-        let _ = trace_num(
+        trace_num(
             "ERROR: account_keylet failed:",
             account_keylet_result as i64,
         );
         return -501; // Account keylet generation failed
     }
-    let _ = trace_data("Account keylet:", &account_keylet_buffer, DataRepr::AsHex);
+    trace_data("Account keylet:", &account_keylet_buffer, DataRepr::AsHex);
 
     // Test 5.2: credential_keylet() - Generate keylet for credential
     let mut credential_keylet_buffer = [0u8; 32];
@@ -601,13 +601,13 @@ fn test_keylet_generation_functions() -> i32 {
     };
 
     if credential_keylet_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: credential_keylet failed (expected - interface issue):",
             credential_keylet_result as i64,
         );
         // This is expected to fail due to unusual parameter types
     } else {
-        let _ = trace_data(
+        trace_data(
             "Credential keylet:",
             &credential_keylet_buffer[..credential_keylet_result as usize],
             DataRepr::AsHex,
@@ -627,10 +627,10 @@ fn test_keylet_generation_functions() -> i32 {
     };
 
     if escrow_keylet_result != 32 {
-        let _ = trace_num("ERROR: escrow_keylet failed:", escrow_keylet_result as i64);
+        trace_num("ERROR: escrow_keylet failed:", escrow_keylet_result as i64);
         return -503; // Escrow keylet generation failed
     }
-    let _ = trace_data("Escrow keylet:", &escrow_keylet_buffer, DataRepr::AsHex);
+    trace_data("Escrow keylet:", &escrow_keylet_buffer, DataRepr::AsHex);
 
     // Test 5.4: oracle_keylet() - Generate keylet for oracle
     let mut oracle_keylet_buffer = [0u8; 32];
@@ -645,19 +645,19 @@ fn test_keylet_generation_functions() -> i32 {
     };
 
     if oracle_keylet_result != 32 {
-        let _ = trace_num("ERROR: oracle_keylet failed:", oracle_keylet_result as i64);
+        trace_num("ERROR: oracle_keylet failed:", oracle_keylet_result as i64);
         return -504; // Oracle keylet generation failed
     }
-    let _ = trace_data("Oracle keylet:", &oracle_keylet_buffer, DataRepr::AsHex);
+    trace_data("Oracle keylet:", &oracle_keylet_buffer, DataRepr::AsHex);
 
-    let _ = trace("SUCCESS: Keylet generation functions");
+    trace("SUCCESS: Keylet generation functions");
     0
 }
 
 /// Test Category 6: Utility Functions (4 functions)
 /// Tests utility functions for hashing, NFT access, and tracing
 fn test_utility_functions() -> i32 {
-    let _ = trace("--- Category 6: Utility Functions ---");
+    trace("--- Category 6: Utility Functions ---");
 
     // Test 6.1: compute_sha512_half() - SHA512 hash computation (first 32 bytes)
     let test_data = b"Hello, XRPL WASM world!";
@@ -672,11 +672,11 @@ fn test_utility_functions() -> i32 {
     };
 
     if hash_result != 32 {
-        let _ = trace_num("ERROR: compute_sha512_half failed:", hash_result as i64);
+        trace_num("ERROR: compute_sha512_half failed:", hash_result as i64);
         return -601; // SHA512 half computation failed
     }
-    let _ = trace_data("Input data:", test_data, DataRepr::AsHex);
-    let _ = trace_data("SHA512 half hash:", &hash_output, DataRepr::AsHex);
+    trace_data("Input data:", test_data, DataRepr::AsHex);
+    trace_data("SHA512 half hash:", &hash_output, DataRepr::AsHex);
 
     // Test 6.2: get_nft() - NFT data retrieval
     let escrow_finish = EscrowFinish;
@@ -695,14 +695,14 @@ fn test_utility_functions() -> i32 {
     };
 
     if nft_result <= 0 {
-        let _ = trace_num(
+        trace_num(
             "INFO: get_nft failed (expected - no such NFT):",
             nft_result as i64,
         );
         // This is expected - test account likely doesn't own the dummy NFT
     } else {
-        let _ = trace_num("NFT data length:", nft_result as i64);
-        let _ = trace_data(
+        trace_num("NFT data length:", nft_result as i64);
+        trace_data(
             "NFT data:",
             &nft_buffer[..nft_result as usize],
             DataRepr::AsHex,
@@ -723,34 +723,34 @@ fn test_utility_functions() -> i32 {
     };
 
     if trace_result < 0 {
-        let _ = trace_num("ERROR: trace() failed:", trace_result as i64);
+        trace_num("ERROR: trace() failed:", trace_result as i64);
         return -603; // Trace function failed
     }
-    let _ = trace_num("Trace function bytes written:", trace_result as i64);
+    trace_num("Trace function bytes written:", trace_result as i64);
 
     // Test 6.4: trace_num() - Debug logging with number
     let test_number = 42i64;
-    let trace_num_result = trace_num("Test number trace", test_number);
+    let trace_num_result = trace_num_with_result("Test number trace", test_number);
 
     use xrpl_wasm_std::host::Result;
     match trace_num_result {
         Result::Ok(_) => {
-            let _ = trace_num("Trace_num function succeeded", 0);
+            trace_num("Trace_num function succeeded", 0);
         }
         Result::Err(_) => {
-            let _ = trace_num("ERROR: trace_num() failed:", -604);
+            trace_num("ERROR: trace_num() failed:", -604);
             return -604; // Trace number function failed
         }
     }
 
-    let _ = trace("SUCCESS: Utility functions");
+    trace("SUCCESS: Utility functions");
     0
 }
 
 /// Test Category 7: Data Update Functions (1 function)
 /// Tests the function for modifying the current ledger entry
 fn test_data_update_functions() -> i32 {
-    let _ = trace("--- Category 7: Data Update Functions ---");
+    trace("--- Category 7: Data Update Functions ---");
 
     // Test 7.1: update_data() - Update current ledger entry data
     let update_payload = b"Updated ledger entry data from WASM test";
@@ -758,15 +758,15 @@ fn test_data_update_functions() -> i32 {
     let update_result = unsafe { host::update_data(update_payload.as_ptr(), update_payload.len()) };
 
     if update_result != 0 {
-        let _ = trace_num("ERROR: update_data failed:", update_result as i64);
+        trace_num("ERROR: update_data failed:", update_result as i64);
         return -701; // Data update failed
     }
 
-    let _ = trace_data(
+    trace_data(
         "Successfully updated ledger entry with:",
         update_payload,
         DataRepr::AsHex,
     );
-    let _ = trace("SUCCESS: Data update functions");
+    trace("SUCCESS: Data update functions");
     1 // <-- Finish the escrow to indicate a successful outcome
 }

--- a/projects/e2e-tests/host_functions_test/src/lib.rs
+++ b/projects/e2e-tests/host_functions_test/src/lib.rs
@@ -28,7 +28,9 @@ extern crate std;
 use xrpl_wasm_std::core::current_tx::escrow_finish::EscrowFinish;
 use xrpl_wasm_std::core::current_tx::traits::TransactionCommonFields;
 use xrpl_wasm_std::host;
-use xrpl_wasm_std::host::trace::{DataRepr, trace, trace_account_buf, trace_data, trace_num, trace_num_with_result};
+use xrpl_wasm_std::host::trace::{
+    DataRepr, trace, trace_account_buf, trace_data, trace_num, trace_num_with_result,
+};
 use xrpl_wasm_std::sfield;
 
 #[unsafe(no_mangle)]

--- a/projects/e2e-tests/keylet_exists/src/lib.rs
+++ b/projects/e2e-tests/keylet_exists/src/lib.rs
@@ -24,33 +24,33 @@ pub fn object_exists(
 ) -> Result<bool> {
     match keylet_result {
         Ok(keylet) => {
-            let _ = trace_data(keylet_type, &keylet, DataRepr::AsHex);
+            trace_data(keylet_type, &keylet, DataRepr::AsHex);
 
             let slot = unsafe { host::cache_ledger_obj(keylet.as_ptr(), keylet.len(), 0) };
             if slot <= 0 {
-                let _ = trace_num("Error: ", slot.into());
+                trace_num("Error: ", slot.into());
                 return Err(Error::from_code(slot));
             }
             if field == 0 {
                 let new_field = sfield::PreviousTxnID;
-                let _ = trace_num("Getting field: ", new_field.into());
+                trace_num("Getting field: ", new_field.into());
                 match ledger_object::get_hash_256_field(slot, new_field) {
                     Ok(data) => {
-                        let _ = trace_data("Field data: ", &data.0, DataRepr::AsHex);
+                        trace_data("Field data: ", &data.0, DataRepr::AsHex);
                     }
                     Err(result_code) => {
-                        let _ = trace_num("Error getting field: ", result_code.into());
+                        trace_num("Error getting field: ", result_code.into());
                         return Err(result_code);
                     }
                 }
             } else {
-                let _ = trace_num("Getting field: ", field.into());
+                trace_num("Getting field: ", field.into());
                 match ledger_object::get_account_id_field(slot, field) {
                     Ok(data) => {
-                        let _ = trace_data("Field data: ", &data.0, DataRepr::AsHex);
+                        trace_data("Field data: ", &data.0, DataRepr::AsHex);
                     }
                     Err(result_code) => {
-                        let _ = trace_num("Error getting field: ", result_code.into());
+                        trace_num("Error getting field: ", result_code.into());
                         return Err(result_code);
                     }
                 }
@@ -59,7 +59,7 @@ pub fn object_exists(
             Ok(true)
         }
         Err(error) => {
-            let _ = trace_num("Error getting keylet: ", error.into());
+            trace_num("Error getting keylet: ", error.into());
             Err(error)
         }
     }
@@ -67,15 +67,15 @@ pub fn object_exists(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
 
     let escrow: CurrentEscrow = get_current_escrow();
 
     let account = escrow.get_account().unwrap_or_panic();
-    let _ = trace_account("Account:", &account);
+    trace_account("Account:", &account);
 
     let destination = escrow.get_destination().unwrap_or_panic();
-    let _ = trace_account("Destination:", &destination);
+    trace_account("Destination:", &destination);
 
     let mut seq = 5;
 
@@ -84,13 +84,13 @@ pub extern "C" fn finish() -> i32 {
             match object_exists($keylet, $type, $field) {
                 Ok(_exists) => {
                     // false isn't returned
-                    let _ = trace(concat!(
+                    trace(concat!(
                         $type,
                         " object exists, proceeding with escrow finish."
                     ));
                 }
                 Err(error) => {
-                    let _ = trace_num("Current seq value:", seq.try_into().unwrap());
+                    trace_num("Current seq value:", seq.try_into().unwrap());
                     return error.code();
                 }
             }

--- a/projects/e2e-tests/trace_escrow_account/src/lib.rs
+++ b/projects/e2e-tests/trace_escrow_account/src/lib.rs
@@ -15,8 +15,8 @@ use xrpl_wasm_std::{assert_eq, decode_hex_32};
 
 #[unsafe(no_mangle)]
 pub extern "C" fn finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
-    let _ = trace("");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("");
 
     // The transaction prompting execution of this contract.
     let escrow_finish: EscrowFinish = get_current_escrow_finish();
@@ -25,8 +25,8 @@ pub extern "C" fn finish() -> i32 {
     // Step #1 [EscrowFinish Account]: Trace Current Balance
     // ########################################
     {
-        let _ = trace("### Step #1: Trace Account Balance for Account Finishing the Escrow");
-        let _ = trace("{ ");
+        trace("### Step #1: Trace Account Balance for Account Finishing the Escrow");
+        trace("{ ");
         let account: AccountID = escrow_finish.get_account().unwrap();
         let balance = match get_account_balance(&account).unwrap().unwrap() {
             TokenAmount::XRP { num_drops } => num_drops,
@@ -41,9 +41,9 @@ pub extern "C" fn finish() -> i32 {
         // GET some other field... can't due to not knowing
 
         assert_eq!(balance, 55426479402);
-        let _ = trace_num("  Balance of Account Finishing the Escrow:", balance);
-        let _ = trace("}");
-        let _ = trace("");
+        trace_num("  Balance of Account Finishing the Escrow:", balance);
+        trace("}");
+        trace("");
     }
 
     // ########################################
@@ -59,32 +59,32 @@ pub extern "C" fn finish() -> i32 {
         // Try to cache the ledger object inside rippled
         let slot = unsafe { cache_ledger_obj(account_keylet.as_ptr(), 32, 0) };
         if slot <= 0 {
-            let _ = trace_num("Error slotting Account object", slot as i64);
+            trace_num("Error slotting Account object", slot as i64);
             panic!()
         } else {
-            let _ = trace_num("Account object slotted at", slot as i64);
+            trace_num("Account object slotted at", slot as i64);
         }
 
         // We use the trait-bound implementation so as not to duplicate accessor logic.
         let account = AccountRoot { slot_num: slot };
 
-        let _ = trace("### Step #2: Trace AccountRoot Ledger Object");
-        let _ = trace("{ ");
-        let _ = trace("  -- Common Fields");
+        trace("### Step #2: Trace AccountRoot Ledger Object");
+        trace("{ ");
+        trace("  -- Common Fields");
 
         // Trace the `Flags`
         let flags = account.get_flags().unwrap();
         assert_eq!(flags, 1703936);
-        let _ = trace_num("  Flags:", flags as i64);
+        trace_num("  Flags:", flags as i64);
 
         // Trace the `LedgerEntryType`
         let ledger_entry_type = account.ledger_entry_type().unwrap();
         assert_eq!(ledger_entry_type, 97); // 97 is the code for "AccountRoot"
-        let _ = trace_num("  LedgerEntryType (AccountRoot):", ledger_entry_type as i64);
-        let _ = trace("} ");
+        trace_num("  LedgerEntryType (AccountRoot):", ledger_entry_type as i64);
+        trace("} ");
 
-        let _ = trace("{ ");
-        let _ = trace("  -- Account Specific Fields");
+        trace("{ ");
+        trace("  -- Account Specific Fields");
 
         // Trace the `Account`
         let account_id = account.get_account().unwrap();
@@ -95,7 +95,7 @@ pub extern "C" fn finish() -> i32 {
                 0xCF, 0xF8, 0xF2, 0xF9, 0x37, 0xE8
             ]
         );
-        let _ = trace_data("  Account:", &account_id.0, DataRepr::AsHex);
+        trace_data("  Account:", &account_id.0, DataRepr::AsHex);
 
         // Trace the `AccountTxnID`
         let account_txn_id = account.account_txn_id().unwrap().unwrap();
@@ -107,7 +107,7 @@ pub extern "C" fn finish() -> i32 {
                 0xDF, 0x14, 0xA1, 0x1E
             ]
         );
-        let _ = trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
+        trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
 
         // Trace `AMMID`
         let amm_id = account.amm_id().unwrap().unwrap();
@@ -119,7 +119,7 @@ pub extern "C" fn finish() -> i32 {
                 0xDF, 0x14, 0xA1, 0x1E
             ]
         );
-        let _ = trace_data("  AMMID:", &amm_id.0, DataRepr::AsHex);
+        trace_data("  AMMID:", &amm_id.0, DataRepr::AsHex);
 
         // Trace the `Balance`
         let balance = match account.balance().unwrap().unwrap() {
@@ -132,17 +132,17 @@ pub extern "C" fn finish() -> i32 {
             }
         };
         assert_eq!(balance, 55426479402);
-        let _ = trace_num("  Balance of arbitrary Account:", balance);
+        trace_num("  Balance of arbitrary Account:", balance);
 
         // Trace the `BurnedNFTokens`
         let burned_nf_tokens = account.burned_nf_tokens().unwrap().unwrap();
         assert_eq!(burned_nf_tokens, 20);
-        let _ = trace_num("  BurnedNFTokens:", burned_nf_tokens as i64);
+        trace_num("  BurnedNFTokens:", burned_nf_tokens as i64);
 
         // Trace the `Domain`
         let domain = account.domain().unwrap().unwrap();
         assert_eq!(&domain.data[..domain.len], &[0xC8, 0xE8, 0xB4, 0x6E]);
-        let _ = trace_data("  Domain:", &domain.data[..domain.len], DataRepr::AsHex);
+        trace_data("  Domain:", &domain.data[..domain.len], DataRepr::AsHex);
 
         // Trace the `EmailHash`
         let email_hash = account.email_hash().unwrap().unwrap();
@@ -153,12 +153,12 @@ pub extern "C" fn finish() -> i32 {
                 0x65, 0xEB
             ]
         );
-        let _ = trace_data("  EmailHash:", &email_hash.0, DataRepr::AsHex);
+        trace_data("  EmailHash:", &email_hash.0, DataRepr::AsHex);
 
         // Trace the `FirstNFTokenSequence`
         let first_nf_token_sequence = account.first_nf_token_sequence().unwrap().unwrap();
         assert_eq!(first_nf_token_sequence, 21);
-        let _ = trace_num("  FirstNFTokenSequence:", first_nf_token_sequence as i64);
+        trace_num("  FirstNFTokenSequence:", first_nf_token_sequence as i64);
 
         // Trace the `MessageKey`
         let message_key = account.message_key().unwrap().unwrap();
@@ -166,7 +166,7 @@ pub extern "C" fn finish() -> i32 {
             &message_key.data[..message_key.len],
             &[0xC8, 0xE8, 0xB4, 0x6D]
         );
-        let _ = trace_data(
+        trace_data(
             "  MessageKey:",
             &message_key.data[..message_key.len],
             DataRepr::AsHex,
@@ -175,7 +175,7 @@ pub extern "C" fn finish() -> i32 {
         // Trace the `MintedNFTokens`
         let minted_nf_tokens = account.minted_nf_tokens().unwrap().unwrap();
         assert_eq!(minted_nf_tokens, 22);
-        let _ = trace_num("  MintedNFTokens:", minted_nf_tokens as i64);
+        trace_num("  MintedNFTokens:", minted_nf_tokens as i64);
 
         // Trace the `NFTokenMinter`
         let nf_token_minter = account.nf_token_minter().unwrap().unwrap();
@@ -186,12 +186,12 @@ pub extern "C" fn finish() -> i32 {
                 0xCF, 0xF8, 0xF2, 0xF9, 0x37, 0xE8
             ]
         );
-        let _ = trace_data("  NFTokenMinter:", &nf_token_minter.0, DataRepr::AsHex);
+        trace_data("  NFTokenMinter:", &nf_token_minter.0, DataRepr::AsHex);
 
         // Trace the `OwnerCount`
         let owner_count = account.owner_count().unwrap();
         assert_eq!(owner_count, 1);
-        let _ = trace_num("  OwnerCount:", owner_count as i64);
+        trace_num("  OwnerCount:", owner_count as i64);
 
         // Trace the `PreviousTxnID`
         let previous_txn_id = account.previous_txn_id().unwrap();
@@ -203,12 +203,12 @@ pub extern "C" fn finish() -> i32 {
                 0xDF, 0x14, 0xA1, 0x1F,
             ]
         );
-        let _ = trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
+        trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
 
         // Trace the `PreviousTxnLgrSeq`
         let previous_txn_lgr_seq = account.previous_txn_lgr_seq().unwrap();
         assert_eq!(previous_txn_lgr_seq, 95945324);
-        let _ = trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
+        trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
 
         // Trace the `RegularKey`
         let regular_key = account.regular_key().unwrap().unwrap();
@@ -219,27 +219,27 @@ pub extern "C" fn finish() -> i32 {
                 0xE9, 0x5D, 0x02, 0xDB, 0x7E, 0xE1
             ]
         );
-        let _ = trace_data("  RegularKey:", &regular_key.0, DataRepr::AsHex);
+        trace_data("  RegularKey:", &regular_key.0, DataRepr::AsHex);
 
         // Trace the `Sequence`
         let sequence = account.sequence().unwrap();
         assert_eq!(sequence, 44196);
-        let _ = trace_num("  Sequence:", sequence as i64);
+        trace_num("  Sequence:", sequence as i64);
 
         // Trace the `TicketCount`
         let ticket_count = account.ticket_count().unwrap().unwrap();
         assert_eq!(ticket_count, 23);
-        let _ = trace_num("  TicketCount:", ticket_count as i64);
+        trace_num("  TicketCount:", ticket_count as i64);
 
         // Trace the `TickSize`
         let tick_size = account.tick_size().unwrap().unwrap();
         assert_eq!(tick_size, 24);
-        let _ = trace_num("  TickSize:", tick_size as i64);
+        trace_num("  TickSize:", tick_size as i64);
 
         // Trace the `TransferRate`
         let transfer_rate = account.transfer_rate().unwrap().unwrap();
         assert_eq!(transfer_rate, 1220000000);
-        let _ = trace_num("  TransferRate:", transfer_rate as i64);
+        trace_num("  TransferRate:", transfer_rate as i64);
 
         // Trace the `WalletLocator`
         let wallet_locator = account.wallet_locator().unwrap().unwrap();
@@ -251,17 +251,17 @@ pub extern "C" fn finish() -> i32 {
                 0xDF, 0x14, 0xA1, 0x1D,
             ]
         );
-        let _ = trace_data("  WalletLocator:", &wallet_locator.0, DataRepr::AsHex);
+        trace_data("  WalletLocator:", &wallet_locator.0, DataRepr::AsHex);
 
         // Trace the `WalletSize`
         let wallet_size = account.wallet_size().unwrap().unwrap();
         assert_eq!(wallet_size, 25);
-        let _ = trace_num("  WalletSize:", wallet_size as i64);
+        trace_num("  WalletSize:", wallet_size as i64);
 
-        let _ = trace("}");
-        let _ = trace("");
+        trace("}");
+        trace("");
     }
 
-    let _ = trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
+    trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
     1 // <-- Finish the escrow to indicate a successful outcome
 }

--- a/projects/e2e-tests/trace_escrow_finish/src/lib.rs
+++ b/projects/e2e-tests/trace_escrow_finish/src/lib.rs
@@ -20,8 +20,8 @@ use xrpl_wasm_std::{assert_eq, sfield};
 
 #[unsafe(no_mangle)]
 pub extern "C" fn finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
-    let _ = trace("");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("");
 
     // The transaction prompting execution of this contract.
     let escrow_finish: EscrowFinish = get_current_escrow_finish();
@@ -30,22 +30,22 @@ pub extern "C" fn finish() -> i32 {
     // Trace All EscrowFinish Fields
     // ########################################
     {
-        let _ = trace("### Trace All EscrowFinish Fields");
-        let _ = trace("{ ");
-        let _ = trace("  -- Common Fields");
+        trace("### Trace All EscrowFinish Fields");
+        trace("{ ");
+        trace("  -- Common Fields");
 
         // Trace Field: TransactionID
         let current_tx_id: Hash256 = escrow_finish.get_id().unwrap();
-        let _ = trace_data("  EscrowFinish TxId:", &current_tx_id.0, DataRepr::AsHex);
+        trace_data("  EscrowFinish TxId:", &current_tx_id.0, DataRepr::AsHex);
         assert_eq!(current_tx_id, EXPECTED_TX_ID.into());
 
         // Trace Field: Account
         let account = escrow_finish.get_account().unwrap();
-        let _ = trace_account("  Account:", &account);
+        trace_account("  Account:", &account);
         if account.0.eq(&ACCOUNT_ONE.0) {
-            let _ = trace("    AccountID == ACCOUNT_ONE => TRUE");
+            trace("    AccountID == ACCOUNT_ONE => TRUE");
         } else {
-            let _ = trace("    AccountID == ACCOUNT_ONE => FALSE");
+            trace("    AccountID == ACCOUNT_ONE => FALSE");
             assert_eq!(account, ACCOUNT_ONE);
         }
 
@@ -53,7 +53,7 @@ pub extern "C" fn finish() -> i32 {
         let transaction_type: TransactionType = escrow_finish.get_transaction_type().unwrap();
         assert_eq!(transaction_type, TransactionType::EscrowFinish);
         let tx_type_bytes: [u8; 2] = transaction_type.into();
-        let _ = trace_data(
+        trace_data(
             "  TransactionType (EscrowFinish):",
             &tx_type_bytes,
             DataRepr::AsHex,
@@ -62,67 +62,67 @@ pub extern "C" fn finish() -> i32 {
         // Trace Field: ComputationAllowance
         let computation_allowance: u32 = escrow_finish.get_computation_allowance().unwrap();
         assert_eq!(computation_allowance, 1000001);
-        let _ = trace_num("  ComputationAllowance:", computation_allowance as i64);
+        trace_num("  ComputationAllowance:", computation_allowance as i64);
 
         // Trace Field: Fee
         let fee = escrow_finish.get_fee().unwrap();
-        let _ = trace_amount("  Fee:", &fee);
+        trace_amount("  Fee:", &fee);
 
         // Trace Field: Sequence
         let sequence: u32 = escrow_finish.get_sequence().unwrap();
         assert_eq!(sequence, 4294967295);
-        let _ = trace_num("  Sequence:", sequence as i64);
+        trace_num("  Sequence:", sequence as i64);
 
         // Trace Field: AccountTxnID
         let opt_account_txn_id = escrow_finish.get_account_txn_id().unwrap();
         if let Some(account_txn_id) = opt_account_txn_id {
             assert_eq!(account_txn_id.0, EXPECTED_ACCOUNT_TXN_ID);
-            let _ = trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
+            trace_data("  AccountTxnID:", &account_txn_id.0, DataRepr::AsHex);
         }
 
         // Trace Field: Flags
         let opt_flags = escrow_finish.get_flags().unwrap();
         if let Some(flags) = opt_flags {
             assert_eq!(flags, 4294967294);
-            let _ = trace_num("  Flags:", flags as i64);
+            trace_num("  Flags:", flags as i64);
         }
 
         // Trace Field: LastLedgerSequence
         let opt_last_ledger_sequence = escrow_finish.get_last_ledger_sequence().unwrap();
         if let Some(last_ledger_sequence) = opt_last_ledger_sequence {
             assert_eq!(last_ledger_sequence, 4294967292);
-            let _ = trace_num("  LastLedgerSequence:", last_ledger_sequence as i64);
+            trace_num("  LastLedgerSequence:", last_ledger_sequence as i64);
         }
 
         // Trace Field: NetworkID
         let opt_network_id = escrow_finish.get_network_id().unwrap();
         if let Some(network_id) = opt_network_id {
             assert_eq!(network_id, 4294967291);
-            let _ = trace_num("  NetworkID:", network_id as i64);
+            trace_num("  NetworkID:", network_id as i64);
         }
 
         // Trace Field: SourceTag
         let opt_source_tag = escrow_finish.get_source_tag().unwrap();
         if let Some(source_tag) = opt_source_tag {
             assert_eq!(source_tag, 4294967290);
-            let _ = trace_num("  SourceTag:", source_tag as i64);
+            trace_num("  SourceTag:", source_tag as i64);
         }
 
         // Trace Field: SigningPubKey
         let signing_pub_key = escrow_finish.get_signing_pub_key().unwrap();
         assert_eq!(signing_pub_key.0, EXPECTED_TX_SIGNING_PUB_KEY);
-        let _ = trace_data("  SigningPubKey:", &signing_pub_key.0, DataRepr::AsHex);
+        trace_data("  SigningPubKey:", &signing_pub_key.0, DataRepr::AsHex);
 
         // Trace Field: TicketSequence
         let opt_ticket_sequence = escrow_finish.get_ticket_sequence().unwrap();
         if let Some(ticket_sequence) = opt_ticket_sequence {
             assert_eq!(ticket_sequence, 4294967289);
-            let _ = trace_num("  TicketSequence:", ticket_sequence as i64);
+            trace_num("  TicketSequence:", ticket_sequence as i64);
         }
 
         let array_len = unsafe { host::get_tx_array_len(sfield::Memos) };
         assert_eq!(array_len, 1);
-        let _ = trace_num("  Memos array len:", array_len as i64);
+        trace_num("  Memos array len:", array_len as i64);
 
         let mut memo_buf = [0u8; 1024];
         let mut locator = Locator::new();
@@ -138,8 +138,8 @@ pub extern "C" fn finish() -> i32 {
                 memo_buf.len(),
             )
         };
-        let _ = trace("    Memo #: 1");
-        let _ = trace_data(
+        trace("    Memo #: 1");
+        trace_data(
             "      MemoType:",
             &memo_buf[..output_len as usize],
             DataRepr::AsHex,
@@ -154,7 +154,7 @@ pub extern "C" fn finish() -> i32 {
                 memo_buf.len(),
             )
         };
-        let _ = trace_data(
+        trace_data(
             "      MemoData:",
             &memo_buf[..output_len as usize],
             DataRepr::AsHex,
@@ -169,7 +169,7 @@ pub extern "C" fn finish() -> i32 {
                 memo_buf.len(),
             )
         };
-        let _ = trace_data(
+        trace_data(
             "      MemoFormat:",
             &memo_buf[..output_len as usize],
             DataRepr::AsHex,
@@ -177,7 +177,7 @@ pub extern "C" fn finish() -> i32 {
 
         let array_len = unsafe { host::get_tx_array_len(sfield::Signers) };
         assert_eq!(array_len, 2);
-        let _ = trace_num("  Signers array len:", array_len as i64);
+        trace_num("  Signers array len:", array_len as i64);
 
         for i in 0..array_len {
             let mut buf = [0x00; 64];
@@ -194,11 +194,11 @@ pub extern "C" fn finish() -> i32 {
                 )
             };
             if output_len < 0 {
-                let _ = trace_num("  cannot get Account, error:", output_len as i64);
+                trace_num("  cannot get Account, error:", output_len as i64);
                 panic!()
             }
-            let _ = trace_num("    Signer #:", i as i64);
-            let _ = trace_account_buf("     Account:", &buf[..20].try_into().unwrap());
+            trace_num("    Signer #:", i as i64);
+            trace_account_buf("     Account:", &buf[..20].try_into().unwrap());
 
             locator.repack_last(sfield::TxnSignature);
             let output_len = unsafe {
@@ -210,10 +210,10 @@ pub extern "C" fn finish() -> i32 {
                 )
             };
             if output_len < 0 {
-                let _ = trace_num("  cannot get TxnSignature, error:", output_len as i64);
+                trace_num("  cannot get TxnSignature, error:", output_len as i64);
                 panic!()
             }
-            let _ = trace_data(
+            trace_data(
                 "     TxnSignature:",
                 &buf[..output_len as usize],
                 DataRepr::AsHex,
@@ -232,13 +232,13 @@ pub extern "C" fn finish() -> i32 {
             assert_eq!(signing_pub_key.0, EXPECTED_TX_SIGNING_PUB_KEY);
 
             if output_len < 0 {
-                let _ = trace_num(
+                trace_num(
                     "  Error getting SigningPubKey. error_code = ",
                     output_len as i64,
                 );
                 break;
             }
-            let _ = trace_data(
+            trace_data(
                 "     SigningPubKey:",
                 &buf[..output_len as usize],
                 DataRepr::AsHex,
@@ -249,30 +249,30 @@ pub extern "C" fn finish() -> i32 {
         let mut signature_bytes = [0u8; 71];
         signature_bytes.copy_from_slice(&txn_signature.data[..71]);
         assert_eq!(signature_bytes, EXPECTED_TXN_SIGNATURE);
-        let _ = trace_data("  TxnSignature:", &signature_bytes, DataRepr::AsHex);
+        trace_data("  TxnSignature:", &signature_bytes, DataRepr::AsHex);
 
-        let _ = trace("  -- EscrowFinish Fields");
+        trace("  -- EscrowFinish Fields");
 
         // Trace Field: Account
         let owner: AccountID = escrow_finish.get_owner().unwrap();
-        let _ = trace_account("  Owner:", &owner);
+        trace_account("  Owner:", &owner);
         if owner.0[0].eq(&ACCOUNT_ZERO.0[0]) {
-            let _ = trace("    AccountID == ACCOUNT_ZERO => TRUE");
+            trace("    AccountID == ACCOUNT_ZERO => TRUE");
         } else {
-            let _ = trace("    AccountID == ACCOUNT_ZERO => FALSE");
+            trace("    AccountID == ACCOUNT_ZERO => FALSE");
             assert_eq!(owner, ACCOUNT_ZERO);
         }
 
         // Trace Field: OfferSequence
         let offer_sequence: u32 = escrow_finish.get_offer_sequence().unwrap();
         assert_eq!(offer_sequence, 4294967293);
-        let _ = trace_num("  OfferSequence:", offer_sequence as i64);
+        trace_num("  OfferSequence:", offer_sequence as i64);
 
         // Trace Field: Condition
         let opt_condition = escrow_finish.get_condition().unwrap();
         if let Some(condition) = opt_condition {
             assert_eq!(condition.0, EXPECTED_ESCROW_FINISH_CONDITION);
-            let _ = trace_data("  Condition:", &condition.0, DataRepr::AsHex);
+            trace_data("  Condition:", &condition.0, DataRepr::AsHex);
         }
 
         let opt_fulfillment = escrow_finish.get_fulfillment().unwrap();
@@ -281,7 +281,7 @@ pub extern "C" fn finish() -> i32 {
                 &fulfillment.data[..fulfillment.len],
                 EXPECTED_ESCROW_FINISH_FULFILLMENT
             );
-            let _ = trace_data(
+            trace_data(
                 "  Fulfillment:",
                 &fulfillment.data[..fulfillment.len],
                 DataRepr::AsHex,
@@ -290,7 +290,7 @@ pub extern "C" fn finish() -> i32 {
 
         // CredentialIDs (Array of Hashes)
         let array_len = unsafe { host::get_tx_array_len(sfield::CredentialIDs) };
-        let _ = trace_num("  CredentialIDs array len:", array_len as i64);
+        trace_num("  CredentialIDs array len:", array_len as i64);
         for i in 0..array_len {
             let mut buf = [0x00; 32];
             let mut locator = Locator::new();
@@ -314,18 +314,18 @@ pub extern "C" fn finish() -> i32 {
                 panic!()
             }
 
-            let _ = trace_data(
+            trace_data(
                 "  CredentialID:",
                 &buf[..output_len as usize],
                 DataRepr::AsHex,
             );
         }
 
-        let _ = trace("}");
-        let _ = trace(""); // Newline
+        trace("}");
+        trace(""); // Newline
     }
 
-    let _ = trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
+    trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
     1 // <-- Finish the escrow to indicate a successful outcome
 }
 

--- a/projects/e2e-tests/trace_escrow_ledger_object/src/lib.rs
+++ b/projects/e2e-tests/trace_escrow_ledger_object/src/lib.rs
@@ -13,8 +13,8 @@ use xrpl_wasm_std::host::{Result::Err, Result::Ok};
 
 #[unsafe(no_mangle)]
 pub extern "C" fn finish() -> i32 {
-    let _ = trace("$$$$$ STARTING WASM EXECUTION $$$$$");
-    let _ = trace("");
+    trace("$$$$$ STARTING WASM EXECUTION $$$$$");
+    trace("");
 
     let current_escrow: CurrentEscrow = get_current_escrow();
 
@@ -22,36 +22,36 @@ pub extern "C" fn finish() -> i32 {
     // Trace All Current Escrow Ledger Object Fields
     // ########################################
     {
-        let _ = trace("### Trace Current Escrow Ledger Object Fields");
-        let _ = trace("{ ");
-        let _ = trace("  -- Common Fields");
+        trace("### Trace Current Escrow Ledger Object Fields");
+        trace("{ ");
+        trace("  -- Common Fields");
 
         // Trace Field: Account
         let account = current_escrow.get_account().unwrap();
         assert_eq!(account.0, EXPECTED_CURRENT_ESCROW_ACCOUNT_ID);
-        let _ = trace_data("  Account:", &account.0, DataRepr::AsHex);
+        trace_data("  Account:", &account.0, DataRepr::AsHex);
 
         // Trace Field: Amount
         let amount = current_escrow.get_amount().unwrap();
-        let _ = trace_amount("  Amount:", &amount);
+        trace_amount("  Amount:", &amount);
 
         // Trace Field: LedgerEntryType
         let ledger_entry_type = current_escrow.get_ledger_entry_type().unwrap();
         assert_eq!(ledger_entry_type, 117);
-        let _ = trace_num("  LedgerEntryType:", ledger_entry_type as i64);
+        trace_num("  LedgerEntryType:", ledger_entry_type as i64);
 
         // Trace Field: CancelAfter
         let opt_cancel_after = current_escrow.get_cancel_after().unwrap();
         if let Some(cancel_after) = opt_cancel_after {
             assert_eq!(cancel_after, 545440232);
-            let _ = trace_num("  CancelAfter:", cancel_after as i64);
+            trace_num("  CancelAfter:", cancel_after as i64);
         }
 
         // Trace Field: Condition
         let opt_condition = current_escrow.get_condition().unwrap();
         if let Some(condition) = opt_condition {
             assert_eq!(condition.0, EXPECTED_ESCROW_CONDITION);
-            let _ = trace_data("  Condition:", &condition.0, DataRepr::AsHex);
+            trace_data("  Condition:", &condition.0, DataRepr::AsHex);
         }
 
         // Trace Field: Destination
@@ -61,36 +61,36 @@ pub extern "C" fn finish() -> i32 {
             0xD6, 0x72, 0x4E, 0xF5, 0x37, 0x54,
         ];
         assert_eq!(destination.0, EXPECTED_DESTINATION);
-        let _ = trace_data("  Destination:", &destination.0, DataRepr::AsHex);
+        trace_data("  Destination:", &destination.0, DataRepr::AsHex);
 
         // Trace Field: DestinationTag
         let opt_destination_tag = current_escrow.get_destination_tag().unwrap();
         if let Some(destination_tag) = opt_destination_tag {
             assert_eq!(destination_tag, 23480);
-            let _ = trace_num("  DestinationTag:", destination_tag as i64);
+            trace_num("  DestinationTag:", destination_tag as i64);
         }
 
         // Trace Field: FinishAfter
         let opt_finish_after = current_escrow.get_finish_after().unwrap();
         if let Some(finish_after) = opt_finish_after {
             assert_eq!(finish_after, 545354132);
-            let _ = trace_num("  FinishAfter:", finish_after as i64);
+            trace_num("  FinishAfter:", finish_after as i64);
         }
 
         // Trace Field: Flags
         let result = current_escrow.get_get_flags();
         if let Ok(flags) = result {
             assert_eq!(flags, 0);
-            let _ = trace_num("  Flags:", flags as i64);
+            trace_num("  Flags:", flags as i64);
         } else if let Err(error) = result {
-            let _ = trace_num("  Error getting Flags. error_code = ", error.code() as i64);
+            trace_num("  Error getting Flags. error_code = ", error.code() as i64);
         }
 
         // Trace Field: FinishFunction
         let opt_finish_function = current_escrow.get_finish_function().unwrap();
         if let Some(finish_function) = opt_finish_function {
             assert_eq!(finish_function.len, 172);
-            let _ = trace_data(
+            trace_data(
                 "  FinishFunction:",
                 &finish_function.data[..finish_function.len],
                 DataRepr::AsHex,
@@ -100,13 +100,13 @@ pub extern "C" fn finish() -> i32 {
         // Trace Field: OwnerNode
         let owner_node = current_escrow.get_owner_node().unwrap();
         assert_eq!(owner_node, 0);
-        let _ = trace_num("  OwnerNode:", owner_node as i64);
+        trace_num("  OwnerNode:", owner_node as i64);
 
         // Trace Field: DestinationNode
         let opt_destination_node = current_escrow.get_destination_node().unwrap();
         if let Some(destination_node) = opt_destination_node {
             assert_eq!(destination_node, 0);
-            let _ = trace_num("  DestinationNode:", destination_node as i64);
+            trace_num("  DestinationNode:", destination_node as i64);
         }
 
         // Trace Field: PreviousTxnID
@@ -119,30 +119,30 @@ pub extern "C" fn finish() -> i32 {
                 0x30, 0x13, 0x1D, 0xA7,
             ]
         );
-        let _ = trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
+        trace_data("  PreviousTxnID:", &previous_txn_id.0, DataRepr::AsHex);
 
         // Trace Field: PreviousTxnLgrSeq
         let previous_txn_lgr_seq = current_escrow.get_previous_txn_lgr_seq().unwrap();
         assert_eq!(previous_txn_lgr_seq, 28991004);
-        let _ = trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
+        trace_num("  PreviousTxnLgrSeq:", previous_txn_lgr_seq as i64);
 
         // Trace Field: SourceTag
         let opt_source_tag = current_escrow.get_source_tag().unwrap();
         if let Some(source_tag) = opt_source_tag {
             assert_eq!(source_tag, 11747);
-            let _ = trace_num("  SourceTag:", 11747);
+            trace_num("  SourceTag:", 11747);
         }
 
         // Trace Field: `index` or `LedgerIndex`
         // The current decision is that this field should not be accessible from the ledger object.
         // let ledger_index = current_escrow.get_ledger_index().unwrap();
-        // let _ = trace_data("  index:", &ledger_index.0, DataRepr::AsHex);
+        // trace_data("  index:", &ledger_index.0, DataRepr::AsHex);
 
-        let _ = trace("}");
-        let _ = trace("");
+        trace("}");
+        trace("");
     }
 
-    let _ = trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
+    trace("$$$$$ WASM EXECUTION COMPLETE $$$$$");
     1 // <-- Finish the escrow to indicate a successful outcome
 }
 

--- a/projects/examples/smart-escrows/kyc/src/lib.rs
+++ b/projects/examples/smart-escrows/kyc/src/lib.rs
@@ -17,7 +17,7 @@ pub extern "C" fn finish() -> i32 {
     let account_id = match current_escrow.get_destination() {
         Ok(account_id) => account_id,
         Err(e) => {
-            let _ = trace_num("Error getting destination", e.code() as i64);
+            trace_num("Error getting destination", e.code() as i64);
             return e.code(); // <-- Do not execute the escrow.
         }
     };
@@ -25,18 +25,18 @@ pub extern "C" fn finish() -> i32 {
     let cred_type: &[u8] = b"termsandconditions";
     match credential_keylet(&account_id, &account_id, cred_type) {
         Ok(keylet) => {
-            let _ = trace_data("cred_keylet", &keylet, DataRepr::AsHex);
+            trace_data("cred_keylet", &keylet, DataRepr::AsHex);
 
             let slot =
                 unsafe { xrpl_wasm_std::host::cache_ledger_obj(keylet.as_ptr(), keylet.len(), 0) };
             if slot < 0 {
-                let _ = trace_num("CACHE ERROR", i64::from(slot));
+                trace_num("CACHE ERROR", i64::from(slot));
                 return 0;
             };
             1 // <-- Finish the escrow to indicate a successful outcome
         }
         Err(e) => {
-            let _ = trace_num("Error getting credential keylet", e.code() as i64);
+            trace_num("Error getting credential keylet", e.code() as i64);
             e.code() // <-- Do not execute the escrow.
         }
     }

--- a/projects/examples/smart-escrows/ledger_sqn/src/lib.rs
+++ b/projects/examples/smart-escrows/ledger_sqn/src/lib.rs
@@ -18,7 +18,7 @@ pub extern "C" fn finish() -> i32 {
         .unwrap()
         .unwrap();
 
-        let _ = trace_num("Ledger Sequence", ledger_sequence as i64);
+        trace_num("Ledger Sequence", ledger_sequence as i64);
         (ledger_sequence >= 5) as i32 // Return 1 if true (successful outcome), 0 if false (failed outcome)
     }
 }

--- a/projects/examples/smart-escrows/nft_owner/src/lib.rs
+++ b/projects/examples/smart-escrows/nft_owner/src/lib.rs
@@ -49,7 +49,7 @@ pub extern "C" fn finish() -> i32 {
             }
         }
         Err(e) => {
-            let _ = trace_num("Error getting first memo:", e.code() as i64);
+            trace_num("Error getting first memo:", e.code() as i64);
             return e.code(); // <-- Do not execute the escrow.
         }
     };
@@ -60,7 +60,7 @@ pub extern "C" fn finish() -> i32 {
     let destination = match current_escrow.get_destination() {
         Ok(destination) => destination,
         Err(e) => {
-            let _ = trace_num("Error getting current ledger destination:", e.code() as i64);
+            trace_num("Error getting current ledger destination:", e.code() as i64);
             return e.code(); // <-- Do not execute the escrow.
         }
     };
@@ -68,7 +68,7 @@ pub extern "C" fn finish() -> i32 {
     match get_nft(&destination, &nft) {
         Ok(_) => 1, // <-- Finish the escrow to indicate a successful outcome
         Err(e) => {
-            let _ = trace_num("Error getting first memo:", e.code() as i64);
+            trace_num("Error getting first memo:", e.code() as i64);
             e.code() // <-- Do not execute the escrow.
         }
     }

--- a/projects/examples/smart-escrows/notary/src/lib.rs
+++ b/projects/examples/smart-escrows/notary/src/lib.rs
@@ -19,7 +19,7 @@ pub extern "C" fn finish() -> i32 {
     let tx_account = match escrow_finish.get_account() {
         Ok(v) => v,
         Err(e) => {
-            let _ = trace_num("Error in Notary contract", e.code() as i64);
+            trace_num("Error in Notary contract", e.code() as i64);
             return e.code(); // Must return to short circuit.
         }
     };

--- a/projects/examples/smart-escrows/notary_macro_example/src/lib.rs
+++ b/projects/examples/smart-escrows/notary_macro_example/src/lib.rs
@@ -24,7 +24,7 @@ pub extern "C" fn finish() -> i32 {
     let tx_account = match escrow_finish.get_account() {
         Ok(v) => v,
         Err(e) => {
-            let _ = trace_num("Error in Notary contract", e.code() as i64);
+            trace_num("Error in Notary contract", e.code() as i64);
             return e.code();
         }
     };

--- a/projects/examples/smart-escrows/oracle/src/lib.rs
+++ b/projects/examples/smart-escrows/oracle/src/lib.rs
@@ -48,7 +48,7 @@ pub fn get_price_from_oracle(slot: i32) -> Result<u64> {
     let asset_price = match match_result_code(result_code, || data) {
         Ok(asset_bytes) => get_u64_from_buffer(&asset_bytes[0..8]),
         Err(error) => {
-            let _ = trace_num("Error getting asset_price", error.code() as i64);
+            trace_num("Error getting asset_price", error.code() as i64);
             return Err(error); // Must return to short circuit.
         }
     };
@@ -60,12 +60,12 @@ pub extern "C" fn finish() -> i32 {
     let oracle_keylet = match oracle_keylet(&ORACLE_OWNER, ORACLE_DOCUMENT_ID) {
         Ok(keylet) => keylet,
         Err(error) => {
-            let _ = trace_data(
+            trace_data(
                 "Failed to get oracle_keylet for account_id=",
                 &ORACLE_OWNER.0,
                 DataRepr::AsHex,
             );
-            let _ = trace_num(
+            trace_num(
                 "Failed to get oracle_keylet for document_id=",
                 ORACLE_DOCUMENT_ID as i64,
             );

--- a/xrpl-wasm-std/README.md
+++ b/xrpl-wasm-std/README.md
@@ -244,15 +244,22 @@ Debug output during development:
 ```rust,ignore
 use xrpl_wasm_std::host::trace::{trace, trace_data, trace_num, DataRepr};
 
-// Simple text trace
-trace("Processing escrow finish")?;
+// Simple text trace (panics on error)
+trace("Processing escrow finish");
 
-// Trace with data
-trace_data("Account ID", &account_id, DataRepr::AsHex)?;
-trace_data("Message", b"Hello", DataRepr::AsUTF8)?;
+// Trace with data (panics on error)
+trace_data("Account ID", &account_id, DataRepr::AsHex);
+trace_data("Message", b"Hello", DataRepr::AsUTF8);
 
-// Trace with number
-trace_num("Balance", balance as i64)?;
+// Trace with number (panics on error)
+trace_num("Balance", balance as i64);
+
+// For error handling, use the _with_result variants:
+use xrpl_wasm_std::host::trace::{trace_with_result, trace_data_with_result, trace_num_with_result};
+
+trace_with_result("Processing escrow finish")?;
+trace_data_with_result("Account ID", &account_id, DataRepr::AsHex)?;
+trace_num_with_result("Balance", balance as i64)?;
 ```
 
 ## Required Module Exports

--- a/xrpl-wasm-std/src/core/locator.rs
+++ b/xrpl-wasm-std/src/core/locator.rs
@@ -11,7 +11,7 @@
 //! l.pack(sfield::Memos);
 //! l.pack(0);
 //! l.pack(sfield::MemoType);
-//! # let _ = (l.len() >= 3);
+//! # (l.len() >= 3);
 //! ```
 
 /// The size of the buffer, in bytes, to use for any new locator

--- a/xrpl-wasm-std/src/core/locator.rs
+++ b/xrpl-wasm-std/src/core/locator.rs
@@ -11,7 +11,7 @@
 //! l.pack(sfield::Memos);
 //! l.pack(0);
 //! l.pack(sfield::MemoType);
-//! # (l.len() >= 3);
+//! # let _ = (l.len() >= 3);
 //! ```
 
 /// The size of the buffer, in bytes, to use for any new locator

--- a/xrpl-wasm-std/src/core/types/amount/token_amount.rs
+++ b/xrpl-wasm-std/src/core/types/amount/token_amount.rs
@@ -207,7 +207,7 @@ impl From<[u8; TOKEN_AMOUNT_SIZE]> for TokenAmount {
         match Self::from_bytes(&bytes) {
             Ok(token_amount) => token_amount,
             Err(error) => {
-                let _ = trace_num("Error parsing token_amount", error.code() as i64);
+                trace_num("Error parsing token_amount", error.code() as i64);
                 panic!("Invalid TokenAmount byte array");
             }
         }

--- a/xrpl-wasm-std/src/core/types/keylets.rs
+++ b/xrpl-wasm-std/src/core/types/keylets.rs
@@ -43,10 +43,10 @@ pub type KeyletBytes = [u8; XRPL_KEYLET_SIZE];
 ///   );
 ///   match account_keylet(&account){
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -99,10 +99,10 @@ pub fn account_keylet(account_id: &AccountID) -> Result<KeyletBytes> {
 ///  let asset2 = Asset::IOU(IouAsset::new(issuer, currency));
 ///  match amm_keylet(&asset1, &asset2) {
 ///    xrpl_wasm_std::host::Result::Ok(keylet) => {
-///      let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///      trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///    }
 ///    xrpl_wasm_std::host::Result::Err(e) => {
-///      let _ = trace_num("Error assembling keylet", e.code() as i64);
+///      trace_num("Error assembling keylet", e.code() as i64);
 ///    }
 ///  }
 ///  Ok(())
@@ -157,10 +157,10 @@ pub fn amm_keylet(issue1: &Asset, issue2: &Asset) -> Result<KeyletBytes> {
 ///   let sequence = 12345;
 ///   match check_keylet(&owner, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -212,10 +212,10 @@ pub fn check_keylet(owner: &AccountID, seq: i32) -> Result<KeyletBytes> {
 ///     let cred_type: &[u8] = b"termsandconditions";
 ///     match credential_keylet(&subject, &issuer, cred_type) {
 ///       xrpl_wasm_std::host::Result::Ok(keylet) => {
-///         let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///         trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///       }
 ///       xrpl_wasm_std::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling keylet", e.code() as i64);
+///         trace_num("Error assembling keylet", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -272,10 +272,10 @@ pub fn credential_keylet(
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match delegate_keylet(&account, &authorize) {
 ///       xrpl_wasm_std::host::Result::Ok(keylet) => {
-///         let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///         trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///       }
 ///       xrpl_wasm_std::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling keylet", e.code() as i64);
+///         trace_num("Error assembling keylet", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -326,10 +326,10 @@ pub fn delegate_keylet(account: &AccountID, authorize: &AccountID) -> Result<Key
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match deposit_preauth_keylet(&account, &authorize) {
 ///       xrpl_wasm_std::host::Result::Ok(keylet) => {
-///         let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///         trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///       }
 ///       xrpl_wasm_std::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling keylet", e.code() as i64);
+///         trace_num("Error assembling keylet", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -381,10 +381,10 @@ pub fn deposit_preauth_keylet(account: &AccountID, authorize: &AccountID) -> Res
 ///   );
 ///   match did_keylet(&account){
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -435,10 +435,10 @@ pub fn did_keylet(account_id: &AccountID) -> Result<KeyletBytes> {
 ///   let sequence = 12345;
 ///   match escrow_keylet(&owner, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -492,10 +492,10 @@ pub fn escrow_keylet(owner: &AccountID, seq: i32) -> Result<KeyletBytes> {
 ///  let currency: CurrencyCode = CurrencyCode::from(*currency_code);
 ///  match line_keylet(&account1, &account2, &currency) {
 ///    xrpl_wasm_std::host::Result::Ok(keylet) => {
-///      let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///      trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///    }
 ///    xrpl_wasm_std::host::Result::Err(e) => {
-///      let _ = trace_num("Error assembling keylet", e.code() as i64);
+///      trace_num("Error assembling keylet", e.code() as i64);
 ///    }
 ///  }
 ///  Ok(())
@@ -554,10 +554,10 @@ pub fn line_keylet(
 ///   let sequence = 12345;
 ///   match mpt_issuance_keylet(&owner, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -609,10 +609,10 @@ pub fn mpt_issuance_keylet(owner: &AccountID, seq: i32) -> Result<KeyletBytes> {
 ///         AccountID::from(*b"\xd5\xb9\x84VP\x9f \xb5'\x9d\x1eJ.\xe8\xb2\xaa\x82\xaec\xe3");
 ///     match mptoken_keylet(&mptid, &holder) {
 ///       xrpl_wasm_std::host::Result::Ok(keylet) => {
-///         let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///         trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///       }
 ///       xrpl_wasm_std::host::Result::Err(e) => {
-///         let _ = trace_num("Error assembling keylet", e.code() as i64);
+///         trace_num("Error assembling keylet", e.code() as i64);
 ///       }
 ///     }
 ///     Ok(())
@@ -665,10 +665,10 @@ pub fn mptoken_keylet(mptid: &MptId, holder: &AccountID) -> Result<KeyletBytes> 
 ///   let sequence = 12345;
 ///   match nft_offer_keylet(&owner, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -720,10 +720,10 @@ pub fn nft_offer_keylet(owner: &AccountID, seq: i32) -> Result<KeyletBytes> {
 ///   let sequence = 12345;
 ///   match offer_keylet(&owner, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -775,10 +775,10 @@ pub fn offer_keylet(owner: &AccountID, seq: i32) -> Result<KeyletBytes> {
 ///   let document_id = 12345;
 ///   match oracle_keylet(&owner, document_id) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -833,10 +833,10 @@ pub fn oracle_keylet(owner: &AccountID, document_id: i32) -> Result<KeyletBytes>
 ///   let sequence = 12345;
 ///   match paychan_keylet(&account, &destination, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -894,10 +894,10 @@ pub fn paychan_keylet(
 ///   let sequence = 12345;
 ///   match permissioned_domain_keylet(&account, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -948,10 +948,10 @@ pub fn permissioned_domain_keylet(account: &AccountID, seq: i32) -> Result<Keyle
 ///   );
 ///   match signers_keylet(&account){
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -1002,10 +1002,10 @@ pub fn signers_keylet(account_id: &AccountID) -> Result<KeyletBytes> {
 ///   let sequence = 12345;
 ///   match ticket_keylet(&owner, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())
@@ -1057,10 +1057,10 @@ pub fn ticket_keylet(owner: &AccountID, seq: i32) -> Result<KeyletBytes> {
 ///   let sequence = 12345;
 ///   match vault_keylet(&account, sequence) {
 ///     xrpl_wasm_std::host::Result::Ok(keylet) => {
-///       let _ = trace_data("Generated keylet", &keylet, DataRepr::AsHex);
+///       trace_data("Generated keylet", &keylet, DataRepr::AsHex);
 ///     }
 ///     xrpl_wasm_std::host::Result::Err(e) => {
-///       let _ = trace_num("Error assembling keylet", e.code() as i64);
+///       trace_num("Error assembling keylet", e.code() as i64);
 ///     }
 ///   }
 ///   Ok(())

--- a/xrpl-wasm-std/src/host/assert.rs
+++ b/xrpl-wasm-std/src/host/assert.rs
@@ -20,7 +20,7 @@ pub fn trace_value<T>(msg: &str, value: &T) {
     let data_ptr = value as *const T as *const u8;
     let data_len = core::mem::size_of::<T>();
     let data_slice = unsafe { core::slice::from_raw_parts(data_ptr, data_len) };
-    let _ = trace_data(msg, data_slice, DataRepr::AsHex);
+    trace_data(msg, data_slice, DataRepr::AsHex);
 }
 
 /// Trace a numeric value.
@@ -38,7 +38,7 @@ macro_rules! impl_numeric_trace {
             impl NumericTrace for $t {
                 #[inline]
                 fn trace_as_num(msg: &str, value: &$t) {
-                    let _ = trace_num(msg, *value as i64);
+                    trace_num(msg, *value as i64);
                 }
             }
         )*
@@ -69,7 +69,7 @@ macro_rules! assert_eq {
             let left_val = $left;
             let right_val = $right;
             if left_val != right_val {
-                let _ = $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
+                $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
                 $crate::host::assert::trace_value("  left: ", &left_val);
                 $crate::host::assert::trace_value("  right: ", &right_val);
                 panic!("assertion failed: {} != {}", stringify!($left), stringify!($right));
@@ -81,10 +81,10 @@ macro_rules! assert_eq {
             let left_val = $left;
             let right_val = $right;
             if left_val != right_val {
-                let _ = $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
+                $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " != ", stringify!($right)));
                 $crate::host::assert::trace_value("  left: ", &left_val);
                 $crate::host::assert::trace_value("  right: ", &right_val);
-                let _ = $crate::host::trace::trace("  message: (see panic message for details)");
+                $crate::host::trace::trace("  message: (see panic message for details)");
                 panic!("assertion failed: {} != {}: {}", stringify!($left), stringify!($right), format_args!($($arg)+));
             }
         }
@@ -109,14 +109,14 @@ macro_rules! assert_eq {
 macro_rules! assert {
     ($cond:expr) => {
         if !$cond {
-            let _ = $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
+            $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
             panic!("assertion failed: {}", stringify!($cond));
         }
     };
     ($cond:expr, $($arg:tt)+) => {
         if !$cond {
-            let _ = $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
-            let _ = $crate::host::trace::trace("  message: (see panic message for details)");
+            $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($cond)));
+            $crate::host::trace::trace("  message: (see panic message for details)");
             panic!("assertion failed: {}: {}", stringify!($cond), format_args!($($arg)+));
         }
     };
@@ -143,7 +143,7 @@ macro_rules! assert_ne {
             let left_val = $left;
             let right_val = $right;
             if left_val == right_val {
-                let _ = $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
+                $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
                 $crate::host::assert::trace_value("  value: ", &left_val);
                 panic!("assertion failed: {} == {}", stringify!($left), stringify!($right));
             }
@@ -154,9 +154,9 @@ macro_rules! assert_ne {
             let left_val = $left;
             let right_val = $right;
             if left_val == right_val {
-                let _ = $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
+                $crate::host::trace::trace(concat!("Assertion failed: ", stringify!($left), " == ", stringify!($right)));
                 $crate::host::assert::trace_value("  value: ", &left_val);
-                let _ = $crate::host::trace::trace("  message: (see panic message for details)");
+                $crate::host::trace::trace("  message: (see panic message for details)");
                 panic!("assertion failed: {} == {}: {}", stringify!($left), stringify!($right), format_args!($($arg)+));
             }
         }

--- a/xrpl-wasm-std/src/host/host_bindings_for_testing.rs
+++ b/xrpl-wasm-std/src/host/host_bindings_for_testing.rs
@@ -4,55 +4,55 @@
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_ledger_sqn() -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_parent_ledger_time() -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_parent_ledger_hash(_out_buff_ptr: *mut u8, _out_buff_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_ledger_account_hash(_out_buff_ptr: *mut u8, _out_buff_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_ledger_tx_hash(_out_buff_ptr: *mut u8, _out_buff_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_base_fee() -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn amendment_enabled(_amendment_ptr: *const u8, _amendment_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn cache_ledger_obj(_keylet_ptr: *const u8, _keylet_len: usize, _cache_num: i32) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_tx_field(_field: i32, _out_buff_ptr: *mut u8, _out_buff_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -62,7 +62,7 @@ pub unsafe fn get_current_ledger_obj_field(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -73,7 +73,7 @@ pub unsafe fn get_ledger_obj_field(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -84,7 +84,7 @@ pub unsafe fn get_tx_nested_field(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -95,7 +95,7 @@ pub unsafe fn get_current_ledger_obj_nested_field(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -107,31 +107,31 @@ pub unsafe fn get_ledger_obj_nested_field(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_tx_array_len(_field: i32) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_current_ledger_obj_array_len(_field: i32) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_ledger_obj_array_len(_cache_num: i32, _field: i32) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_tx_nested_array_len(_locator_ptr: *const u8, _locator_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -140,7 +140,7 @@ pub unsafe fn get_current_ledger_obj_nested_array_len(
     _locator_ptr: *const u8,
     _locator_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -150,13 +150,13 @@ pub unsafe fn get_ledger_obj_nested_array_len(
     _locator_ptr: *const u8,
     _locator_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn update_data(_data_ptr: *const u8, _data_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -167,7 +167,7 @@ pub unsafe fn compute_sha512_half(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -180,7 +180,7 @@ pub unsafe fn check_sig(
     _pubkey_ptr: *const u8,
     _pubkey_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -432,7 +432,7 @@ pub unsafe fn get_nft(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -443,7 +443,7 @@ pub unsafe fn get_nft_issuer(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -454,19 +454,19 @@ pub unsafe fn get_nft_taxon(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_nft_flags(_nft_id_ptr: *const u8, _nft_id_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_nft_transfer_fee(_nft_id_ptr: *const u8, _nft_id_len: usize) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -477,7 +477,7 @@ pub unsafe fn get_nft_serial(
     _out_buff_ptr: *mut u8,
     _out_buff_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -488,7 +488,7 @@ pub unsafe fn float_from_int(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -500,7 +500,7 @@ pub unsafe fn float_from_uint(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -512,7 +512,7 @@ pub unsafe fn float_set(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -523,7 +523,7 @@ pub unsafe fn float_compare(
     _in_buff2: *const u8,
     _in_buff2_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -537,7 +537,7 @@ pub unsafe fn float_add(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -551,7 +551,7 @@ pub unsafe fn float_subtract(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -565,7 +565,7 @@ pub unsafe fn float_multiply(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -579,7 +579,7 @@ pub unsafe fn float_divide(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -592,7 +592,7 @@ pub unsafe fn float_pow(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -605,7 +605,7 @@ pub unsafe fn float_root(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -617,7 +617,7 @@ pub unsafe fn float_log(
     _out_buff_len: usize,
     _rounding_mode: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -629,13 +629,13 @@ pub unsafe fn trace(
     _data_read_len: usize,
     _as_hex: i32,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn trace_num(_msg_read_ptr: *const u8, _msg_read_len: usize, _number: i64) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -646,7 +646,7 @@ pub unsafe fn trace_account(
     _account_ptr: *const u8,
     _account_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -657,7 +657,7 @@ pub unsafe fn trace_opaque_float(
     _opaque_float_ptr: *const u8,
     _opaque_float_len: usize,
 ) -> i32 {
-    -1
+    32
 }
 
 #[allow(unused)]
@@ -668,5 +668,5 @@ pub unsafe fn trace_amount(
     _amount_ptr: *const u8,
     _amount_len: usize,
 ) -> i32 {
-    -1
+    32
 }

--- a/xrpl-wasm-std/src/host/mod.rs
+++ b/xrpl-wasm-std/src/host/mod.rs
@@ -90,7 +90,7 @@ impl<T> Result<T> {
         match self {
             Result::Ok(t) => t,
             Result::Err(error) => {
-                let _ = trace::trace_num("error_code=", error.code() as i64);
+                trace::trace_num("error_code=", error.code() as i64);
                 panic!(
                     "called `Result::unwrap()` on an `Err` with code: {}",
                     error.code()
@@ -120,7 +120,7 @@ impl<T> Result<T> {
     #[inline]
     pub fn unwrap_or_panic(self) -> T {
         self.unwrap_or_else(|error| {
-            let _ = trace::trace_num("error_code=", error.code() as i64);
+            trace::trace_num("error_code=", error.code() as i64);
             core::panic!(
                 "Failed in {}: error_code={}",
                 core::panic::Location::caller(),
@@ -270,10 +270,91 @@ impl Error {
     pub fn code(self) -> i32 {
         self as _
     }
+
+    /// Returns a human-readable description of the error
+    #[inline(always)]
+    pub fn description(self) -> &'static str {
+        match self {
+            Error::InternalError => "Internal error",
+            Error::FieldNotFound => "Field not found",
+            Error::BufferTooSmall => "Buffer too small",
+            Error::NoArray => "Not an array",
+            Error::NotLeafField => "Not a leaf field",
+            Error::LocatorMalformed => "Locator malformed",
+            Error::SlotOutRange => "Slot out of range",
+            Error::SlotsFull => "Slots full",
+            Error::EmptySlot => "Empty slot",
+            Error::LedgerObjNotFound => "Ledger object not found",
+            Error::InvalidDecoding => "Invalid decoding",
+            Error::DataFieldTooLarge => "Data field too large",
+            Error::PointerOutOfBounds => "Pointer out of bounds",
+            Error::NoMemoryExported => "No memory exported",
+            Error::InvalidParams => "Invalid parameters",
+            Error::InvalidAccount => "Invalid account",
+            Error::InvalidField => "Invalid field",
+            Error::IndexOutOfBounds => "Index out of bounds",
+            Error::InvalidFloatInput => "Invalid float input",
+            Error::InvalidFloatComputation => "Invalid float computation",
+        }
+    }
 }
 
 impl From<Error> for i64 {
     fn from(val: Error) -> Self {
         val as i64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_description_all_variants() {
+        // Test that all error variants have non-empty descriptions
+        let test_cases = [
+            (Error::InternalError, "Internal error"),
+            (Error::FieldNotFound, "Field not found"),
+            (Error::BufferTooSmall, "Buffer too small"),
+            (Error::NoArray, "Not an array"),
+            (Error::NotLeafField, "Not a leaf field"),
+            (Error::LocatorMalformed, "Locator malformed"),
+            (Error::SlotOutRange, "Slot out of range"),
+            (Error::SlotsFull, "Slots full"),
+            (Error::EmptySlot, "Empty slot"),
+            (Error::LedgerObjNotFound, "Ledger object not found"),
+            (Error::InvalidDecoding, "Invalid decoding"),
+            (Error::DataFieldTooLarge, "Data field too large"),
+            (Error::PointerOutOfBounds, "Pointer out of bounds"),
+            (Error::NoMemoryExported, "No memory exported"),
+            (Error::InvalidParams, "Invalid parameters"),
+            (Error::InvalidAccount, "Invalid account"),
+            (Error::InvalidField, "Invalid field"),
+            (Error::IndexOutOfBounds, "Index out of bounds"),
+            (Error::InvalidFloatInput, "Invalid float input"),
+            (Error::InvalidFloatComputation, "Invalid float computation"),
+        ];
+
+        for (error, expected_desc) in test_cases {
+            assert_eq!(error.description(), expected_desc);
+            assert!(!error.description().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_error_description_from_code() {
+        // Test that Error::from_code produces errors with correct descriptions
+        let test_cases = [
+            (error_codes::INTERNAL_ERROR, "Internal error"),
+            (error_codes::FIELD_NOT_FOUND, "Field not found"),
+            (error_codes::BUFFER_TOO_SMALL, "Buffer too small"),
+            (error_codes::INVALID_PARAMS, "Invalid parameters"),
+        ];
+
+        for (code, expected_desc) in test_cases {
+            let error = Error::from_code(code);
+            assert_eq!(error.description(), expected_desc);
+            assert_eq!(error.code(), code);
+        }
     }
 }


### PR DESCRIPTION
Fixes #216 to ensure that any errors in `trace` methods unwrap and expose the error, by implementing the following:

* Makes the default `trace…` methods panic on an error.
* Exposes `trace_with_result` variants for callers that want to handle their own error.

### Type of Change

- [X] Refactor (non-breaking change that only restructures code)

## Release Note

All `trace...` calls will now panic if any error is encountered. Because this should never occur, this is not considered a breaking change. If a developer wants to called a trace function and handle the error manually, the `trace...with_result` variants should be used instead.