### PR TITLE
switch from wasm32-unknown-unknown to wasm32v1-none

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.wasm32v1-none]
-rustflags = ["-C", "target-feature=-bulk-memory"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[target.wasm32-unknown-unknown]
+[target.wasm32v1-none]
 rustflags = ["-C", "target-feature=-bulk-memory"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -18,6 +18,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          components: clippy, rustfmt
       # This runs the pre-commit hooks defined in .pre-commit-config.yaml
       # TODO: figure out how to update to use pre-commit.ci
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Cache dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable

--- a/APEX.md
+++ b/APEX.md
@@ -22,7 +22,7 @@ Configuring WASM build settings...
 > Select optimization level: Aggressive (-Oz: optimize aggressively for size)
 Building WASM module...
 Running cargo build...
-args: ["build", "--target", "wasm32-unknown-unknown", "--release"]
+args: ["build", "--target", "wasm32v1-none", "--release"]
 
     Finished `release` profile [optimized] target(s) in 0.03s
 
@@ -30,7 +30,7 @@ args: ["build", "--target", "wasm32-unknown-unknown", "--release"]
 Build completed successfully!
 
 WASM file location:
-/Users/mvadari/Documents/craft/projects/kyc/target/wasm32-unknown-unknown/release/kyc.wasm
+/Users/mvadari/Documents/craft/projects/kyc/target/wasm32v1-none/release/kyc.wasm
 Size: 1198 bytes
 WASM Fingerprint: w7HwHG281DxCQf43VyE7tx1CFheTop12cM # note, this might be wrong
 > Would you like to export the WASM as hex (copied to clipboard)? No

--- a/craft/src/commands/mod.rs
+++ b/craft/src/commands/mod.rs
@@ -351,7 +351,7 @@ pub async fn configure() -> Result<Config> {
     };
 
     // Always use wasm32v1-none target
-    let target = WasmTarget::UnknownUnknown;
+    let target = WasmTarget::V1None;
 
     let build_modes = vec![
         "Release (optimized, no debug info)",

--- a/craft/src/commands/mod.rs
+++ b/craft/src/commands/mod.rs
@@ -350,7 +350,7 @@ pub async fn configure() -> Result<Config> {
         }
     };
 
-    // Always use wasm32-unknown-unknown target
+    // Always use wasm32v1-none target
     let target = WasmTarget::UnknownUnknown;
 
     let build_modes = vec![

--- a/craft/src/config/mod.rs
+++ b/craft/src/config/mod.rs
@@ -19,7 +19,7 @@ pub enum WasmTarget {
 impl std::fmt::Display for WasmTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WasmTarget::UnknownUnknown => write!(f, "wasm32-unknown-unknown"),
+            WasmTarget::UnknownUnknown => write!(f, "wasm32v1-none"),
             WasmTarget::Wasip1 => write!(f, "wasm32-wasi-preview1"),
         }
     }

--- a/craft/src/config/mod.rs
+++ b/craft/src/config/mod.rs
@@ -12,14 +12,14 @@ pub struct Config {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum WasmTarget {
-    UnknownUnknown,
+    V1None,
     Wasip1,
 }
 
 impl std::fmt::Display for WasmTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WasmTarget::UnknownUnknown => write!(f, "wasm32v1-none"),
+            WasmTarget::V1None => write!(f, "wasm32v1-none"),
             WasmTarget::Wasip1 => write!(f, "wasm32-wasi-preview1"),
         }
     }
@@ -60,7 +60,7 @@ impl std::fmt::Display for OptimizationLevel {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            wasm_target: WasmTarget::UnknownUnknown,
+            wasm_target: WasmTarget::V1None,
             build_mode: BuildMode::Release,
             optimization_level: OptimizationLevel::Small,
             project_path: std::env::current_dir().unwrap_or_default(),

--- a/craft/src/utils/mod.rs
+++ b/craft/src/utils/mod.rs
@@ -103,7 +103,7 @@ fn is_valid_wasm_project(cargo_toml_path: &Path) -> bool {
         content.contains("cdylib") ||
         // Also accept projects that might have wasm-related dependencies
         content.contains("wasm-bindgen") ||
-        content.contains("wasm32-unknown-unknown")
+        content.contains("wasm32v1-none")
     } else {
         false
     }
@@ -581,28 +581,28 @@ pub fn find_wasm_output(project_path: &Path) -> Result<PathBuf> {
     // Try release first, then debug
     let candidates = vec![
         project_dir
-            .join("target/wasm32-unknown-unknown/release")
+            .join("target/wasm32v1-none/release")
             .join(format!("{project_name}.wasm")),
         project_dir
-            .join("target/wasm32-unknown-unknown/release")
+            .join("target/wasm32v1-none/release")
             .join(format!("lib{project_name}.wasm")),
         project_dir
-            .join("target/wasm32-unknown-unknown/debug")
+            .join("target/wasm32v1-none/debug")
             .join(format!("{project_name}.wasm")),
         project_dir
-            .join("target/wasm32-unknown-unknown/debug")
+            .join("target/wasm32v1-none/debug")
             .join(format!("lib{project_name}.wasm")),
         project_main_dir
-            .join("target/wasm32-unknown-unknown/release")
+            .join("target/wasm32v1-none/release")
             .join(format!("{project_name}.wasm")),
         project_main_dir
-            .join("target/wasm32-unknown-unknown/release")
+            .join("target/wasm32v1-none/release")
             .join(format!("lib{project_name}.wasm")),
         project_main_dir
-            .join("target/wasm32-unknown-unknown/debug")
+            .join("target/wasm32v1-none/debug")
             .join(format!("{project_name}.wasm")),
         project_main_dir
-            .join("target/wasm32-unknown-unknown/debug")
+            .join("target/wasm32v1-none/debug")
             .join(format!("lib{project_name}.wasm")),
     ];
 
@@ -613,7 +613,7 @@ pub fn find_wasm_output(project_path: &Path) -> Result<PathBuf> {
     }
 
     Err(anyhow::anyhow!(
-        "No WASM output found for project '{}'.\n\n{}\n  • Run: craft build {}\n  • Make sure the project has a [lib] section in Cargo.toml\n  • Check if the build target is set to wasm32-unknown-unknown\n  • Look for .wasm files in target/wasm32-unknown-unknown/",
+        "No WASM output found for project '{}'.\n\n{}\n  • Run: craft build {}\n  • Make sure the project has a [lib] section in Cargo.toml\n  • Check if the build target is set to wasm32v1-none\n  • Look for .wasm files in target/wasm32v1-none/",
         project_name,
         "Suggestions:",
         project_name

--- a/projects/e2e-tests/decoder_tests/README.md
+++ b/projects/e2e-tests/decoder_tests/README.md
@@ -7,14 +7,14 @@ This WebAssembly module is for testing the decoder in the simulated host.
 Build using:
 
 ```bash
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/decoder_tests.wasm
+./target/wasm32v1-none/release/decoder_tests.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/e2e-tests/float_tests/README.md
+++ b/projects/e2e-tests/float_tests/README.md
@@ -7,14 +7,14 @@ This WebAssembly module tests floating-point operations in wasm-host-simulator.
 Build using:
 
 ```bash
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/float_tests.wasm
+./target/wasm32v1-none/release/float_tests.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/e2e-tests/keylet_exists/README.md
+++ b/projects/e2e-tests/keylet_exists/README.md
@@ -7,14 +7,14 @@ This WebAssembly module is an example using the XRPL std lib to determine if an 
 Build using:
 
 ```bash
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/keylet_example.wasm
+./target/wasm32v1-none/release/keylet_example.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/e2e-tests/trace_escrow_account/README.md
+++ b/projects/e2e-tests/trace_escrow_account/README.md
@@ -12,14 +12,14 @@ Build using:
 
 ```bash
 cargo build
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/trace_escrow_account.wasm
+./target/wasm32v1-none/release/trace_escrow_account.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/e2e-tests/trace_escrow_finish/README.md
+++ b/projects/e2e-tests/trace_escrow_finish/README.md
@@ -12,14 +12,14 @@ Build using:
 
 ```bash
 cargo build
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/trace_escrow_finish.wasm
+./target/wasm32v1-none/release/trace_escrow_finish.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/e2e-tests/trace_escrow_ledger_object/README.md
+++ b/projects/e2e-tests/trace_escrow_ledger_object/README.md
@@ -12,14 +12,14 @@ Build using:
 
 ```bash
 cargo build
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/trace_escrow_ledger_object.wasm
+./target/wasm32v1-none/release/trace_escrow_ledger_object.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/examples/smart-escrows/nft_owner/README.md
+++ b/projects/examples/smart-escrows/nft_owner/README.md
@@ -58,7 +58,7 @@ The contract expects:
 
 ### Prerequisites
 
-- Rust with `wasm32-unknown-unknown` target
+- Rust with `wasm32v1-none` target
   - This is necessary for blockchain deployments because WebAssembly does not require a specific vendor (e.g.,
     `apple`) or operating system (e.g., `darwin`), so both are `unknown`
 - XRPL standard library (dependency)
@@ -66,14 +66,14 @@ The contract expects:
 ### Build Commands
 
 ```bash
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/nft_owner.wasm
+./target/wasm32v1-none/release/nft_owner.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/examples/smart-escrows/notary/README.md
+++ b/projects/examples/smart-escrows/notary/README.md
@@ -15,7 +15,7 @@ returns a non-zero error code from the host.
 
 ## Prerequisites
 
-- Rust toolchain with `wasm32-unknown-unknown` target
+- Rust toolchain with `wasm32v1-none` target
 - Node.js 18+
 - Dependencies installed in `reference/js`:
 
@@ -53,14 +53,14 @@ The notary address is hardcoded in the source code. To change it, edit `src/lib.
 
 ```shell
 cargo build
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 Artifact:
 
 ```
-projects/examples/smart-escrows/notary/target/wasm32-unknown-unknown/release/notary.wasm
+projects/examples/smart-escrows/notary/target/wasm32v1-none/release/notary.wasm
 ```
 
 ### 3) Deploy an escrow using your FinishFunction on Devnet

--- a/projects/examples/smart-escrows/notary_macro_example/README.md
+++ b/projects/examples/smart-escrows/notary_macro_example/README.md
@@ -12,14 +12,14 @@ Otherwise, the escrow does not unlock.
 ### Build Commands
 
 ```bash
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 The resulting WASM file will be located at:
 
 ```
-./target/wasm32-unknown-unknown/release/notary_macro_example.wasm
+./target/wasm32v1-none/release/notary_macro_example.wasm
 ```
 
 ## Running with wasm-host-simulator

--- a/projects/examples/smart-escrows/oracle/README.md
+++ b/projects/examples/smart-escrows/oracle/README.md
@@ -40,7 +40,7 @@ const ORACLE_DOCUMENT_ID: i32 = 1;
 
 ### Prerequisites
 
-- Rust with `wasm32-unknown-unknown` target
+- Rust with `wasm32v1-none` target
   - This is necessary for blockchain deployments because WebAssembly does not require a specific vendor (e.g., `apple`) or operating system (e.g., `darwin`), so both are `unknown`
 - XRPL standard library (dependency)
 
@@ -48,10 +48,10 @@ const ORACLE_DOCUMENT_ID: i32 = 1;
 
 ```bash
 # Debug build
-cargo build --target wasm32-unknown-unknown
+cargo build --target wasm32v1-none
 
 # Release build (optimized)
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none --release
 ```
 
 ## Testing
@@ -63,8 +63,8 @@ A comprehensive integration test is available at [`../oracle_integration_test/`]
 ```bash
 # Build integration tests
 cd ../oracle_integration_test
-cargo build --target wasm32-unknown-unknown
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none
+cargo build --target wasm32v1-none --release
 ```
 
 ### Test Coverage

--- a/reference/js/deploy_sample.js
+++ b/reference/js/deploy_sample.js
@@ -28,7 +28,7 @@ function getFinishFunctionFromFile(filePath) {
   if (filePath.endsWith('.wasm') || filePath.endsWith('.hex')) {
     absolutePath = path.resolve(filePath)
   } else {
-    absolutePath = path.resolve(__dirname, `../../projects/target/wasm32-unknown-unknown/release/${filePath}.wasm`)
+    absolutePath = path.resolve(__dirname, `../../projects/target/wasm32v1-none/release/${filePath}.wasm`)
   }
   try {
       const data = fs.readFileSync(absolutePath)

--- a/reference/js/deploy_sample_standalone.js
+++ b/reference/js/deploy_sample_standalone.js
@@ -28,7 +28,7 @@ function getFinishFunctionFromFile(filePath) {
   if (filePath.endsWith('.wasm')) {
     absolutePath = path.resolve(filePath)
   } else {
-    absolutePath = path.resolve(__dirname, `../../projects/target/wasm32-unknown-unknown/release/${filePath}.wasm`)
+    absolutePath = path.resolve(__dirname, `../../projects/target/wasm32v1-none/release/${filePath}.wasm`)
   }
   try {
     const data = fs.readFileSync(absolutePath)

--- a/reference/js/test.js
+++ b/reference/js/test.js
@@ -1,5 +1,5 @@
 const fs = require('fs'); // Only in Node.js
-const wasmBuffer = fs.readFileSync('../../projects/target/wasm32-unknown-unknown/release/ledger_sqn.wasm');
+const wasmBuffer = fs.readFileSync('../../projects/target/wasm32v1-none/release/ledger_sqn.wasm');
 
 const importObject = {
     host_lib: {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "1.89.0"
 components = ["rustfmt", "clippy"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32v1-none"]
 profile = "minimal"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,7 +86,7 @@ Actions workflows, ensuring perfect consistency between local and CI environment
 - **Permission denied**: Run `chmod +x scripts/*.sh` to make scripts executable
 - **Pre-commit not found**: Run `./scripts/setup.sh` to install dependencies
 - **Node.js required**: Install Node.js for the host function audit, or skip that script
-- **WASM target missing**: The scripts automatically install the `wasm32-unknown-unknown` target
+- **WASM target missing**: The scripts automatically install the `wasm32v1-none` target
 
 ## Script Dependencies
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,26 +19,26 @@ else
 fi
 
 # Ensure wasm32 target is available
-echo "📦 Ensuring wasm32-unknown-unknown target is installed..."
-rustup target add wasm32-unknown-unknown
+echo "📦 Ensuring wasm32v1-none target is installed..."
+rustup target add wasm32v1-none
 
 echo "🏗️  Building Native Workspace..."
 cargo build --workspace $RELEASE_MODE
 
 echo "🏗️  Building xrpl-wasm-std for WASM..."
-cargo build -p xrpl-wasm-std --target wasm32-unknown-unknown $RELEASE_MODE
-cargo rustc -p xrpl-wasm-std --target wasm32-unknown-unknown $RELEASE_MODE -- -D warnings
+cargo build -p xrpl-wasm-std --target wasm32v1-none $RELEASE_MODE
+cargo rustc -p xrpl-wasm-std --target wasm32v1-none $RELEASE_MODE -- -D warnings
 
 echo "🏗️  Building WASM Projects Workspace..."
 cd projects
 echo "🔧 Building projects workspace for WASM"
 if [[ -n "$RELEASE_MODE" ]]; then
     # Only build release if specifically requested
-    cargo build --workspace --target wasm32-unknown-unknown $RELEASE_MODE
+    cargo build --workspace --target wasm32v1-none $RELEASE_MODE
 else
     # Build both debug and release when no specific mode is requested
-    cargo build --workspace --target wasm32-unknown-unknown
-    cargo build --workspace --target wasm32-unknown-unknown --release
+    cargo build --workspace --target wasm32v1-none
+    cargo build --workspace --target wasm32v1-none --release
 fi
 cd ..
 

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -12,15 +12,15 @@ cd "$REPO_ROOT"
 echo "🔧 Running Clippy linting..."
 
 # Ensure wasm32 target is available
-echo "📦 Ensuring wasm32-unknown-unknown target is installed..."
-rustup target add wasm32-unknown-unknown
+echo "📦 Ensuring wasm32v1-none target is installed..."
+rustup target add wasm32v1-none
 
 echo "🔍 Running Clippy on Native Workspace..."
 cargo clippy --workspace --all-targets --all-features -- -Dclippy::all
 
 echo "🔍 Running Clippy on WASM Projects Workspace..."
 cd projects
-cargo clippy --workspace --target wasm32-unknown-unknown --all-features -- -Dclippy::all
+cargo clippy --workspace --target wasm32v1-none --all-features -- -Dclippy::all
 cd ..
 
 echo "✅ Clippy linting passed!"

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -12,8 +12,8 @@ cd "$REPO_ROOT"
 echo "🔧 Running end-to-end tests..."
 
 # Ensure wasm32 target is available
-echo "📦 Ensuring wasm32-unknown-unknown target is installed..."
-rustup target add wasm32-unknown-unknown
+echo "📦 Ensuring wasm32v1-none target is installed..."
+rustup target add wasm32v1-none
 
 echo "🏗️  Building projects..."
 scripts/build.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -26,8 +26,8 @@ rustup toolchain install stable
 rustup default stable
 
 # Add WASM target
-echo "📦 Adding wasm32-unknown-unknown target..."
-rustup target add wasm32-unknown-unknown
+echo "📦 Adding wasm32v1-none target..."
+rustup target add wasm32v1-none
 
 # Note: Pre-commit checks are handled by GitHub Actions using pre-commit/action@v3.0.1
 # Local pre-commit installation is optional for development convenience

--- a/tools/copyRippledFixture.js
+++ b/tools/copyRippledFixture.js
@@ -10,7 +10,7 @@ if (process.argv.length < 4) {
 function main() {
     const projectName = process.argv[2]
     const projectPath = path.resolve(__dirname, `../rippled-tests/${projectName}`)
-    execSync(`(cd ${projectPath} && cargo build --target wasm32-unknown-unknown --release && wasm-opt target/wasm32-unknown-unknown/release/${projectName}.wasm -Oz -o target/wasm32-unknown-unknown/release/${projectName}.wasm)`,
+    execSync(`(cd ${projectPath} && cargo build --target wasm32v1-none --release && wasm-opt target/wasm32v1-none/release/${projectName}.wasm -Oz -o target/wasm32v1-none/release/${projectName}.wasm)`,
         function (error, stdout, stderr) {
             if (stderr) {
                 console.error(`stderr: ${stderr}`)
@@ -24,7 +24,7 @@ function main() {
         }
     )
 
-    const srcPath = path.resolve(__dirname, `../rippled-tests/${projectName}/target/wasm32-unknown-unknown/release/${projectName}.wasm`)
+    const srcPath = path.resolve(__dirname, `../rippled-tests/${projectName}/target/wasm32v1-none/release/${projectName}.wasm`)
     const data = fs.readFileSync(srcPath)
     const wasm = data.toString('hex')
 

--- a/wasm-fingerprint-spec.md
+++ b/wasm-fingerprint-spec.md
@@ -52,7 +52,7 @@ A WASM module fingerprint must:
 npm install --prefix reference/js/wasm-fingerprint
 
 # Generate fingerprint from WASM file
-./reference/js/wasm-fingerprint/wasm-fingerprint.js ./projects/notary/target/wasm32-unknown-unknown/release/notary.wasm
+./reference/js/wasm-fingerprint/wasm-fingerprint.js ./projects/notary/target/wasm32v1-none/release/notary.wasm
 ```
 
 ### Example Rust Implementation

--- a/wasm-host-simulator/src/main.rs
+++ b/wasm-host-simulator/src/main.rs
@@ -107,7 +107,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let wasm_file = base_path
-        .join("target/wasm32-unknown-unknown/debug")
+        .join("target/wasm32v1-none/debug")
         .join(format!("{}.wasm", args.project))
         .to_string_lossy()
         .to_string();

--- a/xrpl-wasm-std/README.md
+++ b/xrpl-wasm-std/README.md
@@ -307,7 +307,7 @@ Contracts compare 20-byte AccountID values. If you have a classic XRPL address (
 Build a contract for WASM and run it with the host:
 
 ```shell
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none --release
 ```
 
 ```shell


### PR DESCRIPTION
## High Level Overview of Change

This PR switches the targets everywhere from `wasm32-unknown-unknown` to `wasm32v1-none`.

Explanations:

* https://doc.rust-lang.org/rustc/platform-support/wasm32-unknown-unknown.html
* https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html

### Context of Change

Newer versions of Rust automatically include non-base parts of the WASM implementation, which are disabled in rippled.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

CI passes.
