### PR TITLE
Build and execute any filesystem path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,6 +459,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tokio",
+ "toml",
  "walkdir",
  "which",
 ]
@@ -2362,6 +2363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,6 +2843,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -3379,6 +3430,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/craft/Cargo.toml
+++ b/craft/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 tokio = { version = "1.47", features = ["full"] }
+toml = "0.8"
 walkdir = "2.4"
 which = "8.0.0"
 

--- a/craft/src/commands/test.rs
+++ b/craft/src/commands/test.rs
@@ -33,14 +33,27 @@ impl TestRunner {
 
         let wasm_host_simulator_path = self.get_wasm_host_simulator_path()?;
 
-        let mut args = vec![
-            "--dir",
-            self.dir.to_str().unwrap(),
-            "--test-case",
-            test_case,
-            "--project",
-            &self.project,
-        ];
+        let mut args: Vec<&str> = Vec::new();
+
+        // If dir points to a .wasm file, pass it via --wasm; otherwise treat as fixtures base via --dir
+        if self
+            .dir
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.eq_ignore_ascii_case("wasm"))
+            .unwrap_or(false)
+        {
+            args.push("--wasm");
+            args.push(self.dir.to_str().unwrap());
+        } else {
+            args.push("--dir");
+            args.push(self.dir.to_str().unwrap());
+        }
+
+        args.push("--test-case");
+        args.push(test_case);
+        args.push("--project");
+        args.push(&self.project);
 
         if let Some(func) = function {
             args.push("--function");

--- a/craft/src/main.rs
+++ b/craft/src/main.rs
@@ -338,15 +338,7 @@ async fn main() -> Result<()> {
 
                 let project_path = if let Some(path) = path {
                     // Validate that the path exists and contains a Cargo.toml
-                    if !path.exists() {
-                        anyhow::bail!("Path does not exist: {}", path.display());
-                    }
-                    if !path.is_dir() {
-                        anyhow::bail!("Path is not a directory: {}", path.display());
-                    }
-                    if !path.join("Cargo.toml").exists() {
-                        anyhow::bail!("No Cargo.toml found in directory: {}", path.display());
-                    }
+                    utils::validate_cargo_project_path(&path)?;
                     path
                 } else if let Some(proj) = project {
                     // Find the project from all discovered WASM projects

--- a/wasm-host-simulator/src/main.rs
+++ b/wasm-host-simulator/src/main.rs
@@ -21,9 +21,13 @@ use std::path::PathBuf;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Path to the WASM file
+    /// Project directory containing fixtures (optional)
     #[arg(long)]
     dir: Option<String>,
+
+    /// Path to the WASM file to execute (optional; if absent, use default projects/<project>/target/...)
+    #[arg(long, alias = "wasm-file")]
+    wasm: Option<String>,
 
     /// Test case to run (success/failure)
     #[arg(short, long, default_value = "success")]
@@ -106,12 +110,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
 
-    let wasm_file = base_path
-        .join("target/wasm32v1-none/debug")
-        .join(format!("{}.wasm", args.project))
-        .to_string_lossy()
-        .to_string();
-
+    let wasm_file = if let Some(w) = args.wasm.clone() {
+        w
+    } else {
+        base_path
+            .join("target/wasm32v1-none/debug")
+            .join(format!("{}.wasm", args.project))
+            .to_string_lossy()
+            .to_string()
+    };
     // Initialize logger with appropriate level
     let log_level = if args.verbose {
         LevelFilter::Debug


### PR DESCRIPTION
## High Level Overview of Change

Enable the `craft build` command to build and execute WASM modules from any filesystem path, not just the current directory or predefined project locations.

Fix #199

### Context of Change

Previously, it was difficult to work with WASM projects located elsewhere on the filesystem.

The fix modifies the build command to accept and properly handle absolute and relative filesystem paths, allowing developers to build WASM modules from any location. This provides greater flexibility in project organization and development workflows.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Release Note

The `craft build` command now supports building WASM modules from any filesystem path. Users can specify absolute or relative paths to build projects.