### PR TITLE
fix: remove `get_ledger_account_hash` and `get_ledger_tx_hash` host functions

### DIFF
--- a/projects/e2e-tests/codecov_tests/src/lib.rs
+++ b/projects/e2e-tests/codecov_tests/src/lib.rs
@@ -74,20 +74,6 @@ pub extern "C" fn finish() -> i32 {
             "get_parent_ledger_hash",
         );
     });
-    with_buffer::<32, _, _>(|ptr, len| {
-        check_result(
-            unsafe { host::get_ledger_account_hash(ptr, len) },
-            32,
-            "get_ledger_account_hash",
-        );
-    });
-    with_buffer::<32, _, _>(|ptr, len| {
-        check_result(
-            unsafe { host::get_ledger_tx_hash(ptr, len) },
-            32,
-            "get_ledger_tx_hash",
-        );
-    });
     check_result(unsafe { host::get_base_fee() }, 10, "get_base_fee");
     let amendment_name: &[u8] = b"test_amendment";
     let amendment_id: [u8; 32] = [1; 32];

--- a/scripts/host-function-audit.sh
+++ b/scripts/host-function-audit.sh
@@ -18,7 +18,7 @@ if ! command -v node &> /dev/null; then
 fi
 
 echo "🔍 Auditing host functions to ensure they match XRPLd host functions..."
-node tools/compareHostFunctions.js https://github.com/XRPLF/rippled/tree/ripple/smart-escrow
+node tools/compareHostFunctions.js https://github.com/XRPLF/rippled/tree/ripple/wamr-host-functions
 
 echo "✅ Host function audit completed!"
 echo "ℹ️  Note: This job should not be 'required' for PRs, as during development there may be temporary discrepancies between craft and rippled"

--- a/xrpl-wasm-std/src/host/host_bindings.rs
+++ b/xrpl-wasm-std/src/host/host_bindings.rs
@@ -65,46 +65,6 @@ unsafe extern "C" {
     ///   `../core/error_codes.rs`
     pub fn get_parent_ledger_hash(out_buff_ptr: *mut u8, out_buff_len: usize) -> i32;
 
-    /// Retrieves the account hash of the current ledger.
-    ///
-    /// This function fetches the account hash of the current ledger and stores it in the buffer
-    /// provided. The hash is expected to be written to the memory location pointed by
-    /// `out_buff_ptr`, and its length should not exceed the `out_buff_len`.
-    ///
-    /// # Parameters
-    /// - `out_buff_ptr`: A mutable pointer to a buffer where the account hash will be written.
-    ///   The buffer must be allocated and managed by the caller.
-    /// - `out_buff_len`: The maximum length of the buffer in bytes. This indicates the size of the
-    ///   buffer and ensures that the function does not write beyond the allowed
-    ///   length.
-    ///
-    /// # Returns
-    ///
-    /// - Returns a positive number of bytes wrote to an output buffer on success
-    /// - Returns a negative error code on failure. The list of error codes is defined in
-    ///   ../core/error_codes.rs
-    pub fn get_ledger_account_hash(out_buff_ptr: *mut u8, out_buff_len: usize) -> i32;
-
-    /// Retrieves the transaction hash of the current ledger.
-    ///
-    /// This function fetches the transaction hash of the current ledger and stores it in the buffer
-    /// provided. The hash is expected to be written to the memory location pointed by
-    /// `out_buff_ptr`, and its length should not exceed the `out_buff_len`.
-    ///
-    /// # Parameters
-    /// - `out_buff_ptr`: A mutable pointer to a buffer where the transaction hash will be written.
-    ///   The buffer must be allocated and managed by the caller.
-    /// - `out_buff_len`: The maximum length of the buffer in bytes. This indicates the size of the
-    ///   buffer and ensures that the function does not write beyond the allowed
-    ///   length.
-    ///
-    /// # Returns
-    ///
-    /// - Returns a positive number of bytes wrote to an output buffer on success
-    /// - Returns a negative error code on failure. The list of error codes is defined in
-    ///   ../core/error_codes.rs
-    pub fn get_ledger_tx_hash(out_buff_ptr: *mut u8, out_buff_len: usize) -> i32;
-
     /// Retrieves the current transaction base fee.
     ///
     /// # Returns

--- a/xrpl-wasm-std/src/host/host_bindings_for_testing.rs
+++ b/xrpl-wasm-std/src/host/host_bindings_for_testing.rs
@@ -21,18 +21,6 @@ pub unsafe fn get_parent_ledger_hash(_out_buff_ptr: *mut u8, _out_buff_len: usiz
 
 #[allow(unused)]
 #[allow(clippy::missing_safety_doc)]
-pub unsafe fn get_ledger_account_hash(_out_buff_ptr: *mut u8, _out_buff_len: usize) -> i32 {
-    -1
-}
-
-#[allow(unused)]
-#[allow(clippy::missing_safety_doc)]
-pub unsafe fn get_ledger_tx_hash(_out_buff_ptr: *mut u8, _out_buff_len: usize) -> i32 {
-    -1
-}
-
-#[allow(unused)]
-#[allow(clippy::missing_safety_doc)]
 pub unsafe fn get_base_fee() -> i32 {
     -1
 }


### PR DESCRIPTION
## High Level Overview of Change

Title basically says it all.

### Context of Change

The host functions don't work the way we expected them to. Here's the output from the logs:
_Output in the open ledger:_
```
TRC:OpenLedger WAMR DEV TRACE: parent AB96AB29CACE2B039BB1B6D7A82D7C20A9E406CF1D25ADD557A64663982943AD
TRC:OpenLedger WAMR DEV TRACE: account D271E28FD6B35F007B5B5EDA85008745DB997FC7D1D22AE26E2995184BF5F831
TRC:OpenLedger WAMR DEV TRACE: tx 0000000000000000000000000000000000000000000000000000000000000000
```
_Output in the closed ledger:_
```
TRC:LedgerConsensus WAMR DEV TRACE: parent AB96AB29CACE2B039BB1B6D7A82D7C20A9E406CF1D25ADD557A64663982943AD
TRC:LedgerConsensus WAMR DEV TRACE: account 0000000000000000000000000000000000000000000000000000000000000000
TRC:LedgerConsensus WAMR DEV TRACE: tx 0000000000000000000000000000000000000000000000000000000000000000
```

Note that both are zeroed out in the closed ledger, because we're technically trying to fetch these hashes before they're populated. Therefore this host function doesn't really work.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

These functions were actually not tested at all.