### PR TITLE
Add lib.rs to wasm-host-simulator so that wasm host can be embedded in other programs and tests

### DIFF
--- a/wasm-host-simulator/src/lib.rs
+++ b/wasm-host-simulator/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod data_provider;
+pub mod decoding;
+pub mod hashing;
+pub mod host_functions_wamr;
+pub mod mock_data;
+pub mod sfield;
+pub mod vm_wamr;

--- a/wasm-host-simulator/src/main.rs
+++ b/wasm-host-simulator/src/main.rs
@@ -1,14 +1,5 @@
 extern crate core;
 
-mod data_provider;
-mod decoding;
-mod hashing;
-mod host_functions_wamr;
-mod mock_data;
-mod sfield;
-mod vm_wamr;
-
-use crate::mock_data::MockData;
 use clap::Parser;
 use env_logger::Builder;
 use log::LevelFilter;
@@ -16,6 +7,7 @@ use log::{debug, error, info};
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+use wasm_host_simulator::mock_data::MockData;
 
 /// Wasm WASM testing utility
 #[derive(Parser, Debug)]
@@ -107,7 +99,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let wasm_file = base_path
-        .join("target/wasm32v1-none/debug")
+        .join("target/wasm32v1-none/release")
         .join(format!("{}.wasm", args.project))
         .to_string_lossy()
         .to_string();
@@ -156,7 +148,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let data_source = MockData::new(&tx_json, &lo_json, &lh_json, &l_json, &nft_json);
     info!("Executing function: {}", args.function);
     // TODO: Make Gas Cap optional via https://github.com/ripple/craft/issues/141
-    match vm_wamr::run_func(wasm_file, &args.function, Some(args.gas_cap), data_source) {
+    match wasm_host_simulator::vm_wamr::run_func(
+        wasm_file,
+        Some(&args.function),
+        Some(args.gas_cap),
+        data_source,
+    ) {
         Ok(result) => {
             if (result && args.test_case == "success") || (!result && args.test_case == "failure") {
                 println!("-------------------------------------------------");

--- a/wasm-host-simulator/src/vm_wamr.rs
+++ b/wasm-host-simulator/src/vm_wamr.rs
@@ -1,19 +1,18 @@
 use crate::data_provider::DataProvider;
 use crate::host_functions_wamr::{
-    account_keylet, amm_keylet, cache_ledger_obj, check_keylet, compute_sha512_half,
-    credential_keylet, delegate_keylet, deposit_preauth_keylet, did_keylet, escrow_keylet,
-    float_add, float_compare, float_divide, float_from_int, float_from_uint, float_log,
-    float_multiply, float_pow, float_root, float_set, float_subtract,
-    get_current_ledger_obj_array_len, get_current_ledger_obj_field,
-    get_current_ledger_obj_nested_array_len, get_current_ledger_obj_nested_field,
-    get_ledger_obj_array_len, get_ledger_obj_field, get_ledger_obj_nested_array_len,
-    get_ledger_obj_nested_field, get_ledger_sqn, get_nft, get_parent_ledger_hash,
-    get_parent_ledger_time, get_tx_array_len, get_tx_field, get_tx_nested_array_len,
-    get_tx_nested_field, line_keylet, mpt_issuance_keylet, mptoken_keylet, nft_offer_keylet,
-    offer_keylet, oracle_keylet, paychan_keylet, permissioned_domain_keylet, signers_keylet,
-    ticket_keylet, trace, trace_account, trace_amount, trace_num, trace_opaque_float, update_data,
-    vault_keylet, 
-    bn254_add_helper, bn254_mul_helper, bn254_neg_helper, bn254_pairing_helper,
+    account_keylet, amm_keylet, bn254_add_helper, bn254_mul_helper, bn254_neg_helper,
+    bn254_pairing_helper, cache_ledger_obj, check_keylet, compute_sha512_half, credential_keylet,
+    delegate_keylet, deposit_preauth_keylet, did_keylet, escrow_keylet, float_add, float_compare,
+    float_divide, float_from_int, float_from_uint, float_log, float_multiply, float_pow,
+    float_root, float_set, float_subtract, get_current_ledger_obj_array_len,
+    get_current_ledger_obj_field, get_current_ledger_obj_nested_array_len,
+    get_current_ledger_obj_nested_field, get_ledger_obj_array_len, get_ledger_obj_field,
+    get_ledger_obj_nested_array_len, get_ledger_obj_nested_field, get_ledger_sqn, get_nft,
+    get_parent_ledger_hash, get_parent_ledger_time, get_tx_array_len, get_tx_field,
+    get_tx_nested_array_len, get_tx_nested_field, line_keylet, mpt_issuance_keylet, mptoken_keylet,
+    nft_offer_keylet, offer_keylet, oracle_keylet, paychan_keylet, permissioned_domain_keylet,
+    signers_keylet, ticket_keylet, trace, trace_account, trace_amount, trace_num,
+    trace_opaque_float, update_data, vault_keylet,
 };
 use crate::mock_data::MockData;
 use log::{debug, info, warn};
@@ -28,7 +27,7 @@ use wamr_rust_sdk::value::WasmValue;
 
 #[rustfmt::skip]
 #[allow(unused)]
-pub fn run_func(wasm_file: String, func_name: &str, gas_cap: Option<u32>, data_source: MockData) -> Result<bool, RuntimeError>{
+pub fn run_func(wasm_file: String, func_name: Option<&str>, gas_cap: Option<u32>, data_source: MockData) -> Result<bool, RuntimeError>{
     debug!("Setting up wamr runtime and registering host functions");
     let mut data_provider = DataProvider::new(data_source);
     let runtime = Runtime::builder()
@@ -99,8 +98,9 @@ pub fn run_func(wasm_file: String, func_name: &str, gas_cap: Option<u32>, data_s
     // rippled currently allows 128kb for each VM instance, so we use the same here in Craft.
     let instance = Instance::new(&runtime, &module, 1024 * 128)?;
 
+    let func_name = func_name.unwrap_or("finish");
     debug!("Executing WASM function: {}", func_name);
-    let func = Function::find_export_func(&instance, "finish")?;
+    let func = Function::find_export_func(&instance, func_name)?;
     let gas_begin = gas_cap.map_or(0, |x|x);
     let results = func.call(&instance, &vec![], gas_cap)?;
     match results {


### PR DESCRIPTION
## High Level Overview of Change

- Adds lib.rs to wasm-host-simulator crate allowing it to be used in other crates
- Fixes error where function name parameter was not applied

### Context of Change

This PR came about as I wanted to implement some automated tests for a 3rd party crate that targets the XRPL Wasm runtime. This small change allows for running these tests within the correct environment without having to shell out to a binary host simulator

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Release Note

Adds lib.rs to wasm-host-simulator crate allowing it to be used in other crates

## Test Plan

As this mostly just changes the public API no additional tests were required

## Future Tasks

 N/A

